### PR TITLE
feat(reports): add PDF export for CPR Format 1, 3, and 5 reports

### DIFF
--- a/api/src/api/v1/endpoints/reports.py
+++ b/api/src/api/v1/endpoints/reports.py
@@ -6,7 +6,7 @@ from typing import Annotated, Any
 from uuid import UUID
 
 from fastapi import APIRouter, Query
-from fastapi.responses import HTMLResponse
+from fastapi.responses import HTMLResponse, Response
 
 from src.api.v1.endpoints.dependencies import CurrentUser
 from src.core.deps import DbSession
@@ -21,6 +21,7 @@ from src.schemas.cpr_format5 import Format5ExportConfig
 from src.services.cpr_format3_generator import CPRFormat3Generator
 from src.services.cpr_format5_generator import CPRFormat5Generator
 from src.services.report_generator import ReportGenerator
+from src.services.report_pdf_generator import PDFConfig, ReportPDFGenerator
 
 router = APIRouter()
 
@@ -372,3 +373,238 @@ def _format5_to_dict(report) -> dict[str, Any]:
         return obj
 
     return convert_decimals(result)
+
+
+# ============================================================================
+# PDF Export Endpoints
+# ============================================================================
+
+
+@router.get("/cpr/{program_id}/pdf")
+async def generate_cpr_format1_pdf(
+    program_id: UUID,
+    db: DbSession,
+    period_id: Annotated[UUID | None, Query(description="Specific period ID")] = None,
+    landscape: Annotated[bool, Query(description="Use landscape orientation")] = True,
+) -> Response:
+    """
+    Generate CPR Format 1 (WBS Summary) report as PDF.
+
+    Returns a downloadable PDF file.
+    If period_id is not specified, uses the latest approved period
+    (or latest period if none approved).
+    """
+    # Get program
+    program_repo = ProgramRepository(db)
+    program = await program_repo.get_by_id(program_id)
+    if not program:
+        raise NotFoundError(f"Program {program_id} not found", "PROGRAM_NOT_FOUND")
+
+    # Get period
+    period_repo = EVMSPeriodRepository(db)
+
+    if period_id:
+        period = await period_repo.get_with_data(period_id)
+        if not period:
+            raise NotFoundError(f"Period {period_id} not found", "PERIOD_NOT_FOUND")
+    else:
+        period = await period_repo.get_latest_period(program_id)
+        if not period:
+            raise NotFoundError(
+                "No EVMS periods found for this program",
+                "NO_PERIODS_FOUND",
+            )
+        period = await period_repo.get_with_data(period.id)
+
+    # Get WBS elements
+    wbs_repo = WBSElementRepository(db)
+    wbs_elements = await wbs_repo.get_by_program(program_id)
+
+    # Generate report data
+    generator = ReportGenerator(
+        program=program,
+        period=period,
+        period_data=list(period.period_data) if period.period_data else [],
+        wbs_elements=wbs_elements,
+    )
+    report = generator.generate_cpr_format1()
+
+    # Generate PDF
+    pdf_config = PDFConfig(landscape_mode=landscape)
+    pdf_generator = ReportPDFGenerator(config=pdf_config)
+    pdf_bytes = pdf_generator.generate_format1_pdf(report)
+
+    filename = f"CPR_Format1_{program.code}_{period.period_name.replace(' ', '_')}.pdf"
+
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get("/cpr-format3/{program_id}/pdf")
+async def generate_cpr_format3_pdf(
+    program_id: UUID,
+    db: DbSession,
+    current_user: CurrentUser,
+    baseline_id: Annotated[
+        UUID | None, Query(description="Specific baseline ID (defaults to approved PMB)")
+    ] = None,
+    landscape: Annotated[bool, Query(description="Use landscape orientation")] = True,
+) -> Response:
+    """
+    Generate CPR Format 3 (Baseline) report as PDF.
+
+    Shows time-phased Performance Measurement Baseline (PMB)
+    with actual performance overlay per DFARS requirements.
+    """
+    # Get program
+    program_repo = ProgramRepository(db)
+    program = await program_repo.get_by_id(program_id)
+    if not program:
+        raise NotFoundError(f"Program {program_id} not found", "PROGRAM_NOT_FOUND")
+
+    # Check authorization
+    if program.owner_id != current_user.id and not current_user.is_admin:
+        raise AuthorizationError("Access denied to this program")
+
+    # Get baseline
+    baseline_repo = BaselineRepository(db)
+    if baseline_id:
+        baseline = await baseline_repo.get_by_id(baseline_id)
+        if not baseline:
+            raise NotFoundError(f"Baseline {baseline_id} not found", "BASELINE_NOT_FOUND")
+        if baseline.program_id != program_id:
+            raise NotFoundError("Baseline does not belong to this program", "BASELINE_MISMATCH")
+    else:
+        baseline = await baseline_repo.get_approved_baseline(program_id)
+        if not baseline:
+            baselines = await baseline_repo.get_by_program(program_id)
+            if baselines:
+                baseline = baselines[0]
+            else:
+                raise NotFoundError(
+                    "No baseline found for program. Create a baseline first.",
+                    "NO_BASELINE_FOUND",
+                )
+
+    # Get EVMS periods
+    evms_repo = EVMSPeriodRepository(db)
+    periods = await evms_repo.get_by_program(program_id)
+
+    # Generate report data
+    generator = CPRFormat3Generator(program, baseline, periods)
+    report = generator.generate()
+
+    # Generate PDF
+    pdf_config = PDFConfig(landscape_mode=landscape)
+    pdf_generator = ReportPDFGenerator(config=pdf_config)
+    pdf_bytes = pdf_generator.generate_format3_pdf(report)
+
+    filename = f"CPR_Format3_{program.code}_{baseline.name.replace(' ', '_')}.pdf"
+
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )
+
+
+@router.get("/cpr-format5/{program_id}/pdf")
+async def generate_cpr_format5_pdf(
+    program_id: UUID,
+    db: DbSession,
+    current_user: CurrentUser,
+    periods_to_include: Annotated[
+        int, Query(description="Number of periods to include", ge=1, le=36)
+    ] = 12,
+    variance_threshold: Annotated[
+        Decimal, Query(description="Variance threshold percentage for explanations")
+    ] = Decimal("10"),
+    include_mr: Annotated[bool, Query(description="Include Management Reserve tracking")] = True,
+    include_explanations: Annotated[
+        bool, Query(description="Include variance explanations")
+    ] = True,
+    manager_etc: Annotated[
+        Decimal | None, Query(description="Manager's estimate to complete for independent EAC")
+    ] = None,
+    landscape: Annotated[bool, Query(description="Use landscape orientation")] = True,
+) -> Response:
+    """
+    Generate CPR Format 5 (EVMS) report as PDF.
+
+    Provides detailed EVMS performance data per DFARS requirements:
+    - Monthly/quarterly BCWS, BCWP, ACWP data
+    - All 6 EAC calculation methods per GL 27
+    - Variance percentages and trends
+    - Management Reserve (MR) changes
+    - Narrative variance explanations
+    """
+    # Get program
+    program_repo = ProgramRepository(db)
+    program = await program_repo.get_by_id(program_id)
+    if not program:
+        raise NotFoundError(f"Program {program_id} not found", "PROGRAM_NOT_FOUND")
+
+    # Check authorization
+    if program.owner_id != current_user.id and not current_user.is_admin:
+        raise AuthorizationError("Access denied to this program")
+
+    # Get EVMS periods
+    evms_repo = EVMSPeriodRepository(db)
+    periods = await evms_repo.get_by_program(program_id)
+
+    if not periods:
+        raise NotFoundError(
+            "No EVMS periods found for this program",
+            "NO_PERIODS_FOUND",
+        )
+
+    # Get variance explanations if requested
+    variance_explanations = []
+    if include_explanations:
+        ve_repo = VarianceExplanationRepository(db)
+        variance_explanations = await ve_repo.get_by_program(program_id)
+
+    # Get MR logs if requested
+    mr_logs = []
+    if include_mr:
+        mr_repo = ManagementReserveLogRepository(db)
+        mr_logs = await mr_repo.get_history(program_id, limit=periods_to_include)
+
+    # Create configuration
+    config = Format5ExportConfig(
+        include_mr=include_mr,
+        include_explanations=include_explanations,
+        variance_threshold_percent=variance_threshold,
+        periods_to_include=periods_to_include,
+        include_eac_analysis=True,
+    )
+
+    # Generate report data
+    generator = CPRFormat5Generator(
+        program=program,
+        periods=periods,
+        config=config,
+        variance_explanations=variance_explanations,
+        mr_logs=mr_logs,
+        manager_etc=manager_etc,
+    )
+    report = generator.generate()
+
+    # Generate PDF
+    pdf_config = PDFConfig(landscape_mode=landscape)
+    pdf_generator = ReportPDFGenerator(config=pdf_config)
+    pdf_bytes = pdf_generator.generate_format5_pdf(report)
+
+    # Get latest period for filename
+    latest_period = periods[-1] if periods else None
+    period_name = latest_period.period_name.replace(" ", "_") if latest_period else "current"
+    filename = f"CPR_Format5_{program.code}_{period_name}.pdf"
+
+    return Response(
+        content=pdf_bytes,
+        media_type="application/pdf",
+        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
+    )

--- a/api/src/services/cpr_format5_generator.py
+++ b/api/src/services/cpr_format5_generator.py
@@ -311,10 +311,7 @@ class CPRFormat5Generator:
         eac_typical = (acwp + remaining).quantize(Decimal("0.01"))
 
         # 5. EAC Atypical/Mathematical: ACWP + (BAC - BCWP) / CPI
-        if cpi > 0:
-            eac_atypical = (acwp + (remaining / cpi)).quantize(Decimal("0.01"))
-        else:
-            eac_atypical = bac
+        eac_atypical = (acwp + (remaining / cpi)).quantize(Decimal("0.01")) if cpi > 0 else bac
 
         # 6. EAC Management: Use manager's ETC if provided, otherwise None
         eac_management = None

--- a/api/src/services/report_pdf_generator.py
+++ b/api/src/services/report_pdf_generator.py
@@ -1,0 +1,918 @@
+"""PDF export service for CPR reports.
+
+Generates PDF versions of CPR Format 1, 3, and 5 reports using reportlab.
+Designed for DoD compliance reporting with professional formatting.
+"""
+
+from dataclasses import dataclass, field
+from datetime import date
+from decimal import Decimal
+from io import BytesIO
+from typing import Any
+
+from reportlab.lib import colors
+from reportlab.lib.enums import TA_CENTER, TA_RIGHT
+from reportlab.lib.pagesizes import LETTER, landscape
+from reportlab.lib.styles import ParagraphStyle, getSampleStyleSheet
+from reportlab.lib.units import inch
+from reportlab.platypus import (
+    PageBreak,
+    Paragraph,
+    SimpleDocTemplate,
+    Spacer,
+    Table,
+    TableStyle,
+)
+
+from src.schemas.cpr_format3 import CPRFormat3Report
+from src.schemas.cpr_format5 import CPRFormat5Report
+from src.services.report_generator import CPRFormat1Report
+
+# Default colors for PDF styling
+_DEFAULT_PRIMARY_COLOR = "#1a365d"
+_DEFAULT_ACCENT_COLOR = "#2b6cb0"
+_DEFAULT_POSITIVE_COLOR = "#276749"
+_DEFAULT_NEGATIVE_COLOR = "#c53030"
+
+
+@dataclass
+class PDFConfig:
+    """Configuration for PDF generation."""
+
+    # Page settings
+    page_size: tuple[float, float] = LETTER
+    landscape_mode: bool = True
+    margin_top: float = 0.5 * inch
+    margin_bottom: float = 0.5 * inch
+    margin_left: float = 0.5 * inch
+    margin_right: float = 0.5 * inch
+
+    # Header/footer
+    include_header: bool = True
+    include_footer: bool = True
+    include_page_numbers: bool = True
+
+    # Branding
+    company_name: str = "Defense Program Management"
+    classification: str = "UNCLASSIFIED"
+
+    # Style options (use hex strings, converted to colors at runtime)
+    primary_color_hex: str = field(default=_DEFAULT_PRIMARY_COLOR)
+    accent_color_hex: str = field(default=_DEFAULT_ACCENT_COLOR)
+    positive_color_hex: str = field(default=_DEFAULT_POSITIVE_COLOR)
+    negative_color_hex: str = field(default=_DEFAULT_NEGATIVE_COLOR)
+
+    @property
+    def primary_color(self) -> colors.Color:
+        """Get primary color."""
+        return colors.HexColor(self.primary_color_hex)
+
+    @property
+    def accent_color(self) -> colors.Color:
+        """Get accent color."""
+        return colors.HexColor(self.accent_color_hex)
+
+    @property
+    def positive_color(self) -> colors.Color:
+        """Get positive color."""
+        return colors.HexColor(self.positive_color_hex)
+
+    @property
+    def negative_color(self) -> colors.Color:
+        """Get negative color."""
+        return colors.HexColor(self.negative_color_hex)
+
+
+class ReportPDFGenerator:
+    """Generates PDF versions of CPR reports.
+
+    Supports:
+    - CPR Format 1 (WBS Summary)
+    - CPR Format 3 (Baseline)
+    - CPR Format 5 (EVMS)
+
+    Example usage:
+        pdf_gen = ReportPDFGenerator(config=PDFConfig())
+        pdf_bytes = pdf_gen.generate_format1_pdf(report)
+    """
+
+    def __init__(self, config: PDFConfig | None = None) -> None:
+        """Initialize PDF generator with configuration.
+
+        Args:
+            config: Optional PDF configuration. Uses defaults if not provided.
+        """
+        self.config = config or PDFConfig()
+        self._init_styles()
+
+    def _init_styles(self) -> None:
+        """Initialize paragraph and table styles."""
+        self.styles = getSampleStyleSheet()
+
+        # Title style
+        self.styles.add(
+            ParagraphStyle(
+                "ReportTitle",
+                parent=self.styles["Heading1"],
+                fontSize=16,
+                textColor=self.config.primary_color,
+                spaceAfter=6,
+                alignment=TA_CENTER,
+            )
+        )
+
+        # Subtitle style
+        self.styles.add(
+            ParagraphStyle(
+                "ReportSubtitle",
+                parent=self.styles["Heading2"],
+                fontSize=12,
+                textColor=self.config.accent_color,
+                spaceAfter=12,
+                alignment=TA_CENTER,
+            )
+        )
+
+        # Section header style
+        self.styles.add(
+            ParagraphStyle(
+                "SectionHeader",
+                parent=self.styles["Heading3"],
+                fontSize=11,
+                textColor=self.config.primary_color,
+                spaceBefore=12,
+                spaceAfter=6,
+            )
+        )
+
+        # Normal text style
+        self.styles.add(
+            ParagraphStyle(
+                "ReportBody",
+                parent=self.styles["Normal"],
+                fontSize=9,
+                spaceAfter=6,
+            )
+        )
+
+        # Right-aligned number style
+        self.styles.add(
+            ParagraphStyle(
+                "RightAlign",
+                parent=self.styles["Normal"],
+                fontSize=9,
+                alignment=TA_RIGHT,
+            )
+        )
+
+        # Classification banner
+        self.styles.add(
+            ParagraphStyle(
+                "Classification",
+                parent=self.styles["Normal"],
+                fontSize=10,
+                textColor=colors.green,
+                alignment=TA_CENTER,
+                fontName="Helvetica-Bold",
+            )
+        )
+
+    def _get_page_size(self) -> tuple[float, float]:
+        """Get page size based on configuration."""
+        if self.config.landscape_mode:
+            return landscape(self.config.page_size)
+        return self.config.page_size
+
+    def _format_currency(self, value: Decimal | None) -> str:
+        """Format a decimal value as currency."""
+        if value is None:
+            return "N/A"
+        return f"${value:,.0f}"
+
+    def _format_percent(self, value: Decimal | None) -> str:
+        """Format a decimal value as percentage."""
+        if value is None:
+            return "N/A"
+        return f"{value:.1f}%"
+
+    def _format_index(self, value: Decimal | None) -> str:
+        """Format a performance index value."""
+        if value is None:
+            return "N/A"
+        return f"{value:.2f}"
+
+    def _format_date(self, value: date | None) -> str:
+        """Format a date value."""
+        if value is None:
+            return "N/A"
+        return value.strftime("%b %d, %Y")
+
+    def _create_header_footer(self, canvas: Any, doc: Any) -> None:
+        """Add header and footer to pages."""
+        canvas.saveState()
+        page_width, page_height = self._get_page_size()
+
+        # Classification banner at top
+        if self.config.include_header:
+            canvas.setFont("Helvetica-Bold", 10)
+            canvas.setFillColor(colors.green)
+            canvas.drawCentredString(
+                page_width / 2, page_height - 0.3 * inch, self.config.classification
+            )
+
+        # Footer with page number
+        if self.config.include_footer:
+            canvas.setFont("Helvetica", 8)
+            canvas.setFillColor(colors.gray)
+
+            # Left side: company name
+            canvas.drawString(self.config.margin_left, 0.35 * inch, self.config.company_name)
+
+            # Right side: page number
+            if self.config.include_page_numbers:
+                canvas.drawRightString(
+                    page_width - self.config.margin_right,
+                    0.35 * inch,
+                    f"Page {doc.page}",
+                )
+
+            # Center: classification again
+            canvas.setFillColor(colors.green)
+            canvas.setFont("Helvetica-Bold", 8)
+            canvas.drawCentredString(page_width / 2, 0.35 * inch, self.config.classification)
+
+        canvas.restoreState()
+
+    def _create_summary_table(self, data: list[tuple[str, str]], title: str) -> list[Any]:
+        """Create a summary metrics table.
+
+        Args:
+            data: List of (label, value) tuples
+            title: Section title
+
+        Returns:
+            List of flowables for the summary section
+        """
+        elements = []
+        elements.append(Paragraph(title, self.styles["SectionHeader"]))
+
+        # Create table data
+        table_data = [[label, value] for label, value in data]
+
+        table = Table(
+            table_data,
+            colWidths=[2 * inch, 1.5 * inch],
+            hAlign="LEFT",
+        )
+        table.setStyle(
+            TableStyle(
+                [
+                    ("FONTNAME", (0, 0), (-1, -1), "Helvetica"),
+                    ("FONTSIZE", (0, 0), (-1, -1), 9),
+                    ("ALIGN", (1, 0), (1, -1), "RIGHT"),
+                    ("TOPPADDING", (0, 0), (-1, -1), 3),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+                    ("LINEBELOW", (0, 0), (-1, -1), 0.5, colors.lightgrey),
+                ]
+            )
+        )
+        elements.append(table)
+        elements.append(Spacer(1, 12))
+
+        return elements
+
+    def generate_format1_pdf(self, report: CPRFormat1Report) -> bytes:
+        """Generate PDF for CPR Format 1 (WBS Summary) report.
+
+        Args:
+            report: CPRFormat1Report dataclass
+
+        Returns:
+            PDF file as bytes
+        """
+        buffer = BytesIO()
+        page_size = self._get_page_size()
+
+        doc = SimpleDocTemplate(
+            buffer,
+            pagesize=page_size,
+            topMargin=self.config.margin_top + 0.3 * inch,  # Extra for classification
+            bottomMargin=self.config.margin_bottom + 0.3 * inch,
+            leftMargin=self.config.margin_left,
+            rightMargin=self.config.margin_right,
+        )
+
+        elements = []
+
+        # Title
+        elements.append(
+            Paragraph("Contract Performance Report - Format 1", self.styles["ReportTitle"])
+        )
+        elements.append(
+            Paragraph(
+                f"{report.program_name} ({report.program_code})", self.styles["ReportSubtitle"]
+            )
+        )
+        elements.append(Spacer(1, 6))
+
+        # Header info
+        header_data = [
+            ("Contract Number:", report.contract_number or "N/A"),
+            ("Reporting Period:", report.reporting_period),
+            (
+                "Period:",
+                f"{self._format_date(report.period_start)} - {self._format_date(report.period_end)}",
+            ),
+            ("Report Date:", self._format_date(report.report_date)),
+        ]
+        elements.extend(self._create_summary_table(header_data, "Report Information"))
+
+        # Summary metrics
+        summary_data = [
+            ("Budget at Completion (BAC):", self._format_currency(report.total_bac)),
+            ("BCWS (Planned Value):", self._format_currency(report.total_bcws)),
+            ("BCWP (Earned Value):", self._format_currency(report.total_bcwp)),
+            ("ACWP (Actual Cost):", self._format_currency(report.total_acwp)),
+            ("Cost Variance (CV):", self._format_currency(report.total_cv)),
+            ("Schedule Variance (SV):", self._format_currency(report.total_sv)),
+            ("CPI:", self._format_index(report.total_cpi)),
+            ("SPI:", self._format_index(report.total_spi)),
+            ("EAC:", self._format_currency(report.total_eac)),
+            ("VAC:", self._format_currency(report.total_vac)),
+            ("% Complete:", self._format_percent(report.percent_complete)),
+            ("% Spent:", self._format_percent(report.percent_spent)),
+        ]
+        elements.extend(self._create_summary_table(summary_data, "Performance Summary"))
+
+        # WBS table
+        elements.append(Paragraph("WBS Summary", self.styles["SectionHeader"]))
+
+        # Table headers
+        wbs_headers = [
+            "WBS Code",
+            "Description",
+            "BAC",
+            "BCWS",
+            "BCWP",
+            "ACWP",
+            "CV",
+            "SV",
+            "CPI",
+            "SPI",
+            "EAC",
+            "VAC",
+        ]
+
+        # Build table data
+        wbs_data = [wbs_headers]
+        for row in report.wbs_rows:
+            indent = "  " * (row.level - 1)
+            ca_marker = " *" if row.is_control_account else ""
+            wbs_data.append(
+                [
+                    row.wbs_code,
+                    f"{indent}{row.wbs_name}{ca_marker}",
+                    self._format_currency(row.bac),
+                    self._format_currency(row.bcws),
+                    self._format_currency(row.bcwp),
+                    self._format_currency(row.acwp),
+                    self._format_currency(row.cv),
+                    self._format_currency(row.sv),
+                    self._format_index(row.cpi),
+                    self._format_index(row.spi),
+                    self._format_currency(row.eac),
+                    self._format_currency(row.vac),
+                ]
+            )
+
+        # Add totals row
+        wbs_data.append(
+            [
+                "TOTAL",
+                "",
+                self._format_currency(report.total_bac),
+                self._format_currency(report.total_bcws),
+                self._format_currency(report.total_bcwp),
+                self._format_currency(report.total_acwp),
+                self._format_currency(report.total_cv),
+                self._format_currency(report.total_sv),
+                self._format_index(report.total_cpi),
+                self._format_index(report.total_spi),
+                self._format_currency(report.total_eac),
+                self._format_currency(report.total_vac),
+            ]
+        )
+
+        # Calculate column widths based on page size
+        available_width = page_size[0] - self.config.margin_left - self.config.margin_right
+        col_widths = [
+            0.08 * available_width,  # WBS Code
+            0.18 * available_width,  # Description
+            0.08 * available_width,  # BAC
+            0.08 * available_width,  # BCWS
+            0.08 * available_width,  # BCWP
+            0.08 * available_width,  # ACWP
+            0.08 * available_width,  # CV
+            0.08 * available_width,  # SV
+            0.05 * available_width,  # CPI
+            0.05 * available_width,  # SPI
+            0.08 * available_width,  # EAC
+            0.08 * available_width,  # VAC
+        ]
+
+        wbs_table = Table(wbs_data, colWidths=col_widths)
+
+        # Style table
+        table_style = [
+            # Header row
+            ("BACKGROUND", (0, 0), (-1, 0), self.config.primary_color),
+            ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+            ("FONTSIZE", (0, 0), (-1, 0), 8),
+            ("ALIGN", (0, 0), (-1, 0), "CENTER"),
+            # Body
+            ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
+            ("FONTSIZE", (0, 1), (-1, -1), 7),
+            ("ALIGN", (2, 1), (-1, -1), "RIGHT"),  # Numbers right-aligned
+            ("ALIGN", (0, 1), (1, -1), "LEFT"),  # Text left-aligned
+            # Borders
+            ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+            # Padding
+            ("TOPPADDING", (0, 0), (-1, -1), 2),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 2),
+            # Totals row
+            ("BACKGROUND", (0, -1), (-1, -1), colors.HexColor("#e8f4ff")),
+            ("FONTNAME", (0, -1), (-1, -1), "Helvetica-Bold"),
+            # Alternating row colors
+        ]
+
+        # Add alternating row colors
+        for i in range(1, len(wbs_data) - 1):
+            if i % 2 == 0:
+                table_style.append(("BACKGROUND", (0, i), (-1, i), colors.HexColor("#f9f9f9")))
+
+        # Highlight control accounts
+        for i, row in enumerate(report.wbs_rows, start=1):
+            if row.is_control_account:
+                table_style.append(("BACKGROUND", (0, i), (-1, i), colors.HexColor("#fff3e0")))
+
+        wbs_table.setStyle(TableStyle(table_style))
+        elements.append(wbs_table)
+
+        elements.append(Spacer(1, 6))
+        elements.append(Paragraph("* Indicates Control Account", self.styles["ReportBody"]))
+
+        # Variance notes if any
+        if report.variance_notes:
+            elements.append(Spacer(1, 12))
+            elements.append(Paragraph("Variance Analysis Required", self.styles["SectionHeader"]))
+            for note in report.variance_notes:
+                elements.append(Paragraph(f"• {note}", self.styles["ReportBody"]))
+
+        # Build document
+        doc.build(
+            elements,
+            onFirstPage=self._create_header_footer,
+            onLaterPages=self._create_header_footer,
+        )
+
+        return buffer.getvalue()
+
+    def generate_format3_pdf(self, report: CPRFormat3Report) -> bytes:
+        """Generate PDF for CPR Format 3 (Baseline) report.
+
+        Args:
+            report: CPRFormat3Report dataclass
+
+        Returns:
+            PDF file as bytes
+        """
+        buffer = BytesIO()
+        page_size = self._get_page_size()
+
+        doc = SimpleDocTemplate(
+            buffer,
+            pagesize=page_size,
+            topMargin=self.config.margin_top + 0.3 * inch,
+            bottomMargin=self.config.margin_bottom + 0.3 * inch,
+            leftMargin=self.config.margin_left,
+            rightMargin=self.config.margin_right,
+        )
+
+        elements = []
+
+        # Title
+        elements.append(
+            Paragraph("Contract Performance Report - Format 3", self.styles["ReportTitle"])
+        )
+        elements.append(
+            Paragraph(
+                f"{report.program_name} ({report.program_code})", self.styles["ReportSubtitle"]
+            )
+        )
+        elements.append(Spacer(1, 6))
+
+        # Header info
+        header_data = [
+            ("Contract Number:", report.contract_number or "N/A"),
+            ("Baseline:", f"{report.baseline_name} (v{report.baseline_version})"),
+            ("Report Date:", self._format_date(report.report_date)),
+            ("Current Period:", report.current_period),
+        ]
+        elements.extend(self._create_summary_table(header_data, "Report Information"))
+
+        # Summary metrics
+        summary_data = [
+            ("Budget at Completion (BAC):", self._format_currency(report.bac)),
+            ("Cumulative BCWS:", self._format_currency(report.total_bcws)),
+            ("Cumulative BCWP:", self._format_currency(report.total_bcwp)),
+            ("Cumulative ACWP:", self._format_currency(report.total_acwp)),
+            ("Schedule Variance:", self._format_currency(report.total_sv)),
+            ("Cost Variance:", self._format_currency(report.total_cv)),
+            ("SPI:", self._format_index(report.spi)),
+            ("CPI:", self._format_index(report.cpi)),
+            ("EAC:", self._format_currency(report.eac)),
+            ("ETC:", self._format_currency(report.etc)),
+            ("VAC:", self._format_currency(report.vac)),
+            ("TCPI:", self._format_index(report.tcpi)),
+            ("% Complete:", self._format_percent(report.percent_complete)),
+            ("% Spent:", self._format_percent(report.percent_spent)),
+        ]
+        elements.extend(self._create_summary_table(summary_data, "Performance Summary"))
+
+        # Schedule status
+        schedule_data = [
+            ("Baseline Finish:", self._format_date(report.baseline_finish_date)),
+            ("Forecast Finish:", self._format_date(report.forecast_finish_date)),
+            ("Schedule Variance:", f"{report.schedule_variance_days} days"),
+            ("Status:", "Behind Schedule" if report.is_behind_schedule else "On Schedule"),
+        ]
+        elements.extend(self._create_summary_table(schedule_data, "Schedule Status"))
+
+        # Time-phased data table
+        if report.time_phase_rows:
+            elements.append(Paragraph("Time-Phased Performance", self.styles["SectionHeader"]))
+
+            time_headers = [
+                "Period",
+                "BCWS",
+                "BCWP",
+                "ACWP",
+                "SV",
+                "CV",
+                "Cum BCWS",
+                "Cum BCWP",
+                "Cum ACWP",
+                "SPI",
+                "CPI",
+            ]
+
+            time_data = [time_headers]
+            for row in report.time_phase_rows:
+                time_data.append(
+                    [
+                        row.period_name,
+                        self._format_currency(row.bcws),
+                        self._format_currency(row.bcwp),
+                        self._format_currency(row.acwp),
+                        self._format_currency(row.sv),
+                        self._format_currency(row.cv),
+                        self._format_currency(row.cumulative_bcws),
+                        self._format_currency(row.cumulative_bcwp),
+                        self._format_currency(row.cumulative_acwp),
+                        self._format_index(row.cumulative_spi),
+                        self._format_index(row.cumulative_cpi),
+                    ]
+                )
+
+            available_width = page_size[0] - self.config.margin_left - self.config.margin_right
+            col_widths = [available_width / len(time_headers)] * len(time_headers)
+
+            time_table = Table(time_data, colWidths=col_widths)
+
+            table_style = [
+                ("BACKGROUND", (0, 0), (-1, 0), self.config.primary_color),
+                ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                ("FONTSIZE", (0, 0), (-1, 0), 7),
+                ("ALIGN", (0, 0), (-1, 0), "CENTER"),
+                ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
+                ("FONTSIZE", (0, 1), (-1, -1), 7),
+                ("ALIGN", (1, 1), (-1, -1), "RIGHT"),
+                ("ALIGN", (0, 1), (0, -1), "LEFT"),
+                ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                ("TOPPADDING", (0, 0), (-1, -1), 2),
+                ("BOTTOMPADDING", (0, 0), (-1, -1), 2),
+            ]
+
+            # Add alternating row colors
+            for i in range(1, len(time_data)):
+                if i % 2 == 0:
+                    table_style.append(("BACKGROUND", (0, i), (-1, i), colors.HexColor("#f9f9f9")))
+
+            time_table.setStyle(TableStyle(table_style))
+            elements.append(time_table)
+
+        # Build document
+        doc.build(
+            elements,
+            onFirstPage=self._create_header_footer,
+            onLaterPages=self._create_header_footer,
+        )
+
+        return buffer.getvalue()
+
+    def _build_format5_eac_section(self, report: CPRFormat5Report, elements: list[Any]) -> None:
+        """Build EAC analysis section for Format 5 PDF."""
+        if not report.eac_analysis:
+            return
+
+        eac = report.eac_analysis
+        elements.append(Paragraph("EAC Analysis (Per GL 27)", self.styles["SectionHeader"]))
+
+        eac_data = [
+            ["Method", "EAC Value", "Description"],
+            ["CPI Method", self._format_currency(eac.eac_cpi), "BAC / CPI"],
+            [
+                "SPI Method",
+                self._format_currency(eac.eac_spi) if eac.eac_spi else "N/A",
+                "BAC / SPI",
+            ],
+            [
+                "Composite",
+                self._format_currency(eac.eac_composite),
+                "ACWP + (BAC - BCWP) / (CPI x SPI)",
+            ],
+            ["Typical", self._format_currency(eac.eac_typical), "ACWP + (BAC - BCWP)"],
+            ["Atypical", self._format_currency(eac.eac_atypical), "ACWP + (BAC - BCWP) / CPI"],
+            [
+                "Management",
+                self._format_currency(eac.eac_management) if eac.eac_management else "N/A",
+                "Bottom-up estimate",
+            ],
+        ]
+
+        eac_table = Table(eac_data, colWidths=[1.5 * inch, 1.5 * inch, 4 * inch])
+        eac_table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), self.config.primary_color),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, 0), 9),
+                    ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
+                    ("FONTSIZE", (0, 1), (-1, -1), 8),
+                    ("ALIGN", (1, 1), (1, -1), "RIGHT"),
+                    ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                    ("TOPPADDING", (0, 0), (-1, -1), 3),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+                ]
+            )
+        )
+        elements.append(eac_table)
+
+        elements.append(Spacer(1, 6))
+        elements.append(
+            Paragraph(
+                f"<b>Selected EAC:</b> {self._format_currency(eac.eac_selected)}",
+                self.styles["ReportBody"],
+            )
+        )
+        if eac.selection_rationale:
+            elements.append(
+                Paragraph(f"<b>Rationale:</b> {eac.selection_rationale}", self.styles["ReportBody"])
+            )
+        if eac.eac_range_low and eac.eac_range_high:
+            elements.append(
+                Paragraph(
+                    f"<b>EAC Range:</b> {self._format_currency(eac.eac_range_low)} - {self._format_currency(eac.eac_range_high)}",
+                    self.styles["ReportBody"],
+                )
+            )
+        elements.append(Spacer(1, 12))
+
+    def _build_format5_period_table(
+        self, report: CPRFormat5Report, elements: list[Any], page_size: tuple[float, float]
+    ) -> None:
+        """Build period data table for Format 5 PDF."""
+        if not report.period_rows:
+            return
+
+        elements.append(Paragraph("Period Performance Data", self.styles["SectionHeader"]))
+
+        period_headers = [
+            "Period",
+            "BCWS",
+            "BCWP",
+            "ACWP",
+            "SV",
+            "CV",
+            "SV%",
+            "CV%",
+            "SPI",
+            "CPI",
+            "EAC",
+        ]
+        period_data = [period_headers]
+
+        for row in report.period_rows:
+            period_data.append(
+                [
+                    row.period_name,
+                    self._format_currency(row.bcws),
+                    self._format_currency(row.bcwp),
+                    self._format_currency(row.acwp),
+                    self._format_currency(row.period_sv),
+                    self._format_currency(row.period_cv),
+                    self._format_percent(row.sv_percent),
+                    self._format_percent(row.cv_percent),
+                    self._format_index(row.spi),
+                    self._format_index(row.cpi),
+                    self._format_currency(row.eac),
+                ]
+            )
+
+        available_width = page_size[0] - self.config.margin_left - self.config.margin_right
+        col_widths = [available_width / len(period_headers)] * len(period_headers)
+
+        period_table = Table(period_data, colWidths=col_widths)
+        table_style = [
+            ("BACKGROUND", (0, 0), (-1, 0), self.config.primary_color),
+            ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+            ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+            ("FONTSIZE", (0, 0), (-1, 0), 7),
+            ("ALIGN", (0, 0), (-1, 0), "CENTER"),
+            ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
+            ("FONTSIZE", (0, 1), (-1, -1), 7),
+            ("ALIGN", (1, 1), (-1, -1), "RIGHT"),
+            ("ALIGN", (0, 1), (0, -1), "LEFT"),
+            ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+            ("TOPPADDING", (0, 0), (-1, -1), 2),
+            ("BOTTOMPADDING", (0, 0), (-1, -1), 2),
+        ]
+
+        for i in range(1, len(period_data)):
+            if i % 2 == 0:
+                table_style.append(("BACKGROUND", (0, i), (-1, i), colors.HexColor("#f9f9f9")))
+
+        period_table.setStyle(TableStyle(table_style))
+        elements.append(period_table)
+
+    def _build_format5_mr_section(
+        self, report: CPRFormat5Report, elements: list[Any], page_size: tuple[float, float]
+    ) -> None:
+        """Build Management Reserve section for Format 5 PDF."""
+        if not report.mr_rows:
+            return
+
+        elements.append(PageBreak())
+        elements.append(Paragraph("Management Reserve Tracking", self.styles["SectionHeader"]))
+
+        mr_headers = ["Period", "Beginning MR", "Changes In", "Changes Out", "Ending MR", "Reason"]
+        mr_data = [mr_headers]
+
+        for row in report.mr_rows:
+            mr_data.append(
+                [
+                    row.period_name,
+                    self._format_currency(row.beginning_mr),
+                    self._format_currency(row.changes_in),
+                    self._format_currency(row.changes_out),
+                    self._format_currency(row.ending_mr),
+                    row.reason or "",
+                ]
+            )
+
+        available_width = page_size[0] - self.config.margin_left - self.config.margin_right
+        mr_col_widths = [0.12, 0.14, 0.14, 0.14, 0.14, 0.32]
+        mr_col_widths = [w * available_width for w in mr_col_widths]
+
+        mr_table = Table(mr_data, colWidths=mr_col_widths)
+        mr_table.setStyle(
+            TableStyle(
+                [
+                    ("BACKGROUND", (0, 0), (-1, 0), self.config.primary_color),
+                    ("TEXTCOLOR", (0, 0), (-1, 0), colors.white),
+                    ("FONTNAME", (0, 0), (-1, 0), "Helvetica-Bold"),
+                    ("FONTSIZE", (0, 0), (-1, 0), 8),
+                    ("FONTNAME", (0, 1), (-1, -1), "Helvetica"),
+                    ("FONTSIZE", (0, 1), (-1, -1), 8),
+                    ("ALIGN", (1, 1), (4, -1), "RIGHT"),
+                    ("GRID", (0, 0), (-1, -1), 0.5, colors.grey),
+                    ("TOPPADDING", (0, 0), (-1, -1), 3),
+                    ("BOTTOMPADDING", (0, 0), (-1, -1), 3),
+                ]
+            )
+        )
+        elements.append(mr_table)
+
+    def _build_format5_variance_section(
+        self, report: CPRFormat5Report, elements: list[Any]
+    ) -> None:
+        """Build variance explanations section for Format 5 PDF."""
+        if not report.variance_explanations:
+            return
+
+        elements.append(Spacer(1, 12))
+        elements.append(Paragraph("Variance Explanations", self.styles["SectionHeader"]))
+
+        for exp in report.variance_explanations:
+            var_type = "Schedule" if exp.variance_type == "schedule" else "Cost"
+            header = f"{exp.wbs_code} - {exp.wbs_name} ({var_type} Variance)"
+            elements.append(Paragraph(f"<b>{header}</b>", self.styles["ReportBody"]))
+            elements.append(
+                Paragraph(
+                    f"Variance: {self._format_currency(exp.variance_amount)} ({self._format_percent(exp.variance_percent)})",
+                    self.styles["ReportBody"],
+                )
+            )
+            elements.append(Paragraph(f"Explanation: {exp.explanation}", self.styles["ReportBody"]))
+            if exp.corrective_action:
+                elements.append(
+                    Paragraph(
+                        f"Corrective Action: {exp.corrective_action}", self.styles["ReportBody"]
+                    )
+                )
+            if exp.expected_resolution_date:
+                elements.append(
+                    Paragraph(
+                        f"Expected Resolution: {self._format_date(exp.expected_resolution_date)}",
+                        self.styles["ReportBody"],
+                    )
+                )
+            elements.append(Spacer(1, 6))
+
+    def generate_format5_pdf(self, report: CPRFormat5Report) -> bytes:
+        """Generate PDF for CPR Format 5 (EVMS) report.
+
+        Args:
+            report: CPRFormat5Report dataclass
+
+        Returns:
+            PDF file as bytes
+        """
+        buffer = BytesIO()
+        page_size = self._get_page_size()
+
+        doc = SimpleDocTemplate(
+            buffer,
+            pagesize=page_size,
+            topMargin=self.config.margin_top + 0.3 * inch,
+            bottomMargin=self.config.margin_bottom + 0.3 * inch,
+            leftMargin=self.config.margin_left,
+            rightMargin=self.config.margin_right,
+        )
+
+        elements: list[Any] = []
+
+        # Title
+        elements.append(
+            Paragraph("Contract Performance Report - Format 5", self.styles["ReportTitle"])
+        )
+        elements.append(
+            Paragraph("Earned Value Management System Report", self.styles["ReportSubtitle"])
+        )
+        elements.append(
+            Paragraph(
+                f"{report.program_name} ({report.program_code})", self.styles["ReportSubtitle"]
+            )
+        )
+        elements.append(Spacer(1, 6))
+
+        # Header info
+        header_data = [
+            ("Contract Number:", report.contract_number or "N/A"),
+            ("Report Date:", self._format_date(report.report_date)),
+            ("Reporting Period:", report.reporting_period),
+        ]
+        elements.extend(self._create_summary_table(header_data, "Report Information"))
+
+        # Summary metrics
+        summary_data = [
+            ("Budget at Completion (BAC):", self._format_currency(report.bac)),
+            ("EAC:", self._format_currency(report.current_eac)),
+            ("ETC:", self._format_currency(report.current_etc)),
+            ("VAC:", self._format_currency(report.current_vac)),
+            ("CPI:", self._format_index(report.cumulative_cpi)),
+            ("SPI:", self._format_index(report.cumulative_spi)),
+            ("TCPI:", self._format_index(report.cumulative_tcpi)),
+            ("% Complete:", self._format_percent(report.percent_complete)),
+            ("% Spent:", self._format_percent(report.percent_spent)),
+            ("Management Reserve:", self._format_currency(report.current_mr)),
+        ]
+        elements.extend(self._create_summary_table(summary_data, "Performance Summary"))
+
+        # Build sections via helper methods
+        self._build_format5_eac_section(report, elements)
+        self._build_format5_period_table(report, elements, page_size)
+        self._build_format5_mr_section(report, elements, page_size)
+        self._build_format5_variance_section(report, elements)
+
+        # Build document
+        doc.build(
+            elements,
+            onFirstPage=self._create_header_footer,
+            onLaterPages=self._create_header_footer,
+        )
+
+        return buffer.getvalue()

--- a/api/tests/unit/test_report_pdf_generator.py
+++ b/api/tests/unit/test_report_pdf_generator.py
@@ -1,0 +1,874 @@
+"""Tests for PDF report generation service."""
+
+from datetime import date
+from decimal import Decimal
+
+import pytest
+
+from src.schemas.cpr_format3 import CPRFormat3Report, TimePhaseRow
+from src.schemas.cpr_format5 import (
+    CPRFormat5Report,
+    EACAnalysis,
+    Format5PeriodRow,
+    ManagementReserveRow,
+    VarianceExplanation,
+)
+from src.services.report_generator import CPRFormat1Report, WBSSummaryRow
+from src.services.report_pdf_generator import PDFConfig, ReportPDFGenerator
+
+
+class TestPDFConfig:
+    """Tests for PDFConfig dataclass."""
+
+    def test_default_config(self):
+        """Should create config with default values."""
+        config = PDFConfig()
+
+        assert config.landscape_mode is True
+        assert config.include_header is True
+        assert config.include_footer is True
+        assert config.include_page_numbers is True
+        assert config.classification == "UNCLASSIFIED"
+        assert config.company_name == "Defense Program Management"
+
+    def test_custom_config(self):
+        """Should create config with custom values."""
+        config = PDFConfig(
+            landscape_mode=False,
+            include_header=False,
+            classification="CONFIDENTIAL",
+            company_name="Custom Corp",
+        )
+
+        assert config.landscape_mode is False
+        assert config.include_header is False
+        assert config.classification == "CONFIDENTIAL"
+        assert config.company_name == "Custom Corp"
+
+
+class TestReportPDFGenerator:
+    """Tests for ReportPDFGenerator class."""
+
+    @pytest.fixture
+    def pdf_generator(self) -> ReportPDFGenerator:
+        """Create a PDF generator instance."""
+        return ReportPDFGenerator()
+
+    @pytest.fixture
+    def custom_pdf_generator(self) -> ReportPDFGenerator:
+        """Create a PDF generator with custom config."""
+        config = PDFConfig(
+            landscape_mode=False,
+            classification="FOR OFFICIAL USE ONLY",
+        )
+        return ReportPDFGenerator(config=config)
+
+    @pytest.fixture
+    def sample_format1_report(self) -> CPRFormat1Report:
+        """Create a sample Format 1 report."""
+        wbs_rows = [
+            WBSSummaryRow(
+                wbs_code="1.0",
+                wbs_name="Program Management",
+                level=1,
+                is_control_account=False,
+                bac=Decimal("500000"),
+                bcws=Decimal("200000"),
+                bcwp=Decimal("180000"),
+                acwp=Decimal("190000"),
+                cv=Decimal("-10000"),
+                sv=Decimal("-20000"),
+                cpi=Decimal("0.95"),
+                spi=Decimal("0.90"),
+                eac=Decimal("526316"),
+                etc=Decimal("336316"),
+                vac=Decimal("-26316"),
+            ),
+            WBSSummaryRow(
+                wbs_code="1.1",
+                wbs_name="Project Planning",
+                level=2,
+                is_control_account=True,
+                bac=Decimal("100000"),
+                bcws=Decimal("50000"),
+                bcwp=Decimal("45000"),
+                acwp=Decimal("48000"),
+                cv=Decimal("-3000"),
+                sv=Decimal("-5000"),
+                cpi=Decimal("0.94"),
+                spi=Decimal("0.90"),
+                eac=Decimal("106383"),
+                etc=Decimal("58383"),
+                vac=Decimal("-6383"),
+            ),
+            WBSSummaryRow(
+                wbs_code="1.2",
+                wbs_name="Engineering",
+                level=2,
+                is_control_account=True,
+                bac=Decimal("400000"),
+                bcws=Decimal("150000"),
+                bcwp=Decimal("135000"),
+                acwp=Decimal("142000"),
+                cv=Decimal("-7000"),
+                sv=Decimal("-15000"),
+                cpi=Decimal("0.95"),
+                spi=Decimal("0.90"),
+                eac=Decimal("421053"),
+                etc=Decimal("279053"),
+                vac=Decimal("-21053"),
+            ),
+        ]
+
+        return CPRFormat1Report(
+            program_name="Test Defense Program",
+            program_code="TDP-001",
+            contract_number="W12345-26-C-0001",
+            reporting_period="January 2026",
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 1, 31),
+            report_date=date(2026, 2, 5),
+            total_bac=Decimal("500000"),
+            total_bcws=Decimal("200000"),
+            total_bcwp=Decimal("180000"),
+            total_acwp=Decimal("190000"),
+            total_cv=Decimal("-10000"),
+            total_sv=Decimal("-20000"),
+            total_cpi=Decimal("0.95"),
+            total_spi=Decimal("0.90"),
+            total_eac=Decimal("526316"),
+            total_etc=Decimal("336316"),
+            total_vac=Decimal("-26316"),
+            percent_complete=Decimal("36.00"),
+            percent_spent=Decimal("38.00"),
+            wbs_rows=wbs_rows,
+            variance_notes=[
+                "1.1 (Project Planning): Schedule variance requires explanation.",
+                "1.2 (Engineering): Cost variance of -7000 requires explanation.",
+            ],
+        )
+
+    @pytest.fixture
+    def sample_format3_report(self) -> CPRFormat3Report:
+        """Create a sample Format 3 report."""
+        time_rows = [
+            TimePhaseRow(
+                period_name="October 2025",
+                period_start=date(2025, 10, 1),
+                period_end=date(2025, 10, 31),
+                bcws=Decimal("50000"),
+                bcwp=Decimal("48000"),
+                acwp=Decimal("49000"),
+                cumulative_bcws=Decimal("50000"),
+                cumulative_bcwp=Decimal("48000"),
+                cumulative_acwp=Decimal("49000"),
+                sv=Decimal("-2000"),
+                cv=Decimal("-1000"),
+            ),
+            TimePhaseRow(
+                period_name="November 2025",
+                period_start=date(2025, 11, 1),
+                period_end=date(2025, 11, 30),
+                bcws=Decimal("60000"),
+                bcwp=Decimal("55000"),
+                acwp=Decimal("58000"),
+                cumulative_bcws=Decimal("110000"),
+                cumulative_bcwp=Decimal("103000"),
+                cumulative_acwp=Decimal("107000"),
+                sv=Decimal("-5000"),
+                cv=Decimal("-3000"),
+            ),
+            TimePhaseRow(
+                period_name="December 2025",
+                period_start=date(2025, 12, 1),
+                period_end=date(2025, 12, 31),
+                bcws=Decimal("70000"),
+                bcwp=Decimal("62000"),
+                acwp=Decimal("68000"),
+                cumulative_bcws=Decimal("180000"),
+                cumulative_bcwp=Decimal("165000"),
+                cumulative_acwp=Decimal("175000"),
+                sv=Decimal("-8000"),
+                cv=Decimal("-6000"),
+            ),
+        ]
+
+        return CPRFormat3Report(
+            program_name="Test Defense Program",
+            program_code="TDP-001",
+            contract_number="W12345-26-C-0001",
+            baseline_name="Initial PMB",
+            baseline_version=1,
+            report_date=date(2026, 1, 15),
+            bac=Decimal("1000000"),
+            current_period="December 2025",
+            percent_complete=Decimal("16.50"),
+            percent_spent=Decimal("17.50"),
+            total_bcws=Decimal("180000"),
+            total_bcwp=Decimal("165000"),
+            total_acwp=Decimal("175000"),
+            total_sv=Decimal("-15000"),
+            total_cv=Decimal("-10000"),
+            eac=Decimal("1060606"),
+            etc=Decimal("885606"),
+            vac=Decimal("-60606"),
+            cpi=Decimal("0.94"),
+            spi=Decimal("0.92"),
+            tcpi=Decimal("1.01"),
+            time_phase_rows=time_rows,
+            baseline_finish_date=date(2027, 6, 30),
+            forecast_finish_date=date(2027, 8, 15),
+            schedule_variance_days=46,
+        )
+
+    @pytest.fixture
+    def sample_format5_report(self) -> CPRFormat5Report:
+        """Create a sample Format 5 report."""
+        period_rows = [
+            Format5PeriodRow(
+                period_name="October 2025",
+                period_start=date(2025, 10, 1),
+                period_end=date(2025, 10, 31),
+                bcws=Decimal("50000"),
+                bcwp=Decimal("48000"),
+                acwp=Decimal("49000"),
+                cumulative_bcws=Decimal("50000"),
+                cumulative_bcwp=Decimal("48000"),
+                cumulative_acwp=Decimal("49000"),
+                period_sv=Decimal("-2000"),
+                period_cv=Decimal("-1000"),
+                cumulative_sv=Decimal("-2000"),
+                cumulative_cv=Decimal("-1000"),
+                sv_percent=Decimal("-4.00"),
+                cv_percent=Decimal("-2.00"),
+                spi=Decimal("0.96"),
+                cpi=Decimal("0.98"),
+                eac=Decimal("1020408"),
+                etc=Decimal("971408"),
+                vac=Decimal("-20408"),
+                tcpi=Decimal("1.00"),
+            ),
+            Format5PeriodRow(
+                period_name="November 2025",
+                period_start=date(2025, 11, 1),
+                period_end=date(2025, 11, 30),
+                bcws=Decimal("60000"),
+                bcwp=Decimal("55000"),
+                acwp=Decimal("58000"),
+                cumulative_bcws=Decimal("110000"),
+                cumulative_bcwp=Decimal("103000"),
+                cumulative_acwp=Decimal("107000"),
+                period_sv=Decimal("-5000"),
+                period_cv=Decimal("-3000"),
+                cumulative_sv=Decimal("-7000"),
+                cumulative_cv=Decimal("-4000"),
+                sv_percent=Decimal("-6.36"),
+                cv_percent=Decimal("-3.64"),
+                spi=Decimal("0.94"),
+                cpi=Decimal("0.96"),
+                eac=Decimal("1041667"),
+                etc=Decimal("934667"),
+                vac=Decimal("-41667"),
+                tcpi=Decimal("1.00"),
+            ),
+        ]
+
+        mr_rows = [
+            ManagementReserveRow(
+                period_name="October 2025",
+                beginning_mr=Decimal("100000"),
+                changes_in=Decimal("0"),
+                changes_out=Decimal("5000"),
+                ending_mr=Decimal("95000"),
+                reason="Released to WBS 1.2 for unplanned testing",
+            ),
+            ManagementReserveRow(
+                period_name="November 2025",
+                beginning_mr=Decimal("95000"),
+                changes_in=Decimal("0"),
+                changes_out=Decimal("10000"),
+                ending_mr=Decimal("85000"),
+                reason="Released to WBS 1.1 for scope change",
+            ),
+        ]
+
+        variance_explanations = [
+            VarianceExplanation(
+                wbs_code="1.1",
+                wbs_name="Project Planning",
+                variance_type="cost",
+                variance_amount=Decimal("-15000"),
+                variance_percent=Decimal("-12.5"),
+                explanation="Unplanned contractor support required for requirements analysis.",
+                corrective_action="Reassigning internal staff to reduce contractor dependency.",
+                expected_resolution_date=date(2026, 2, 28),
+            ),
+            VarianceExplanation(
+                wbs_code="1.2",
+                wbs_name="Engineering",
+                variance_type="schedule",
+                variance_amount=Decimal("-20000"),
+                variance_percent=Decimal("-11.1"),
+                explanation="Design review delayed due to stakeholder availability.",
+                corrective_action="Accelerated review schedule implemented.",
+                expected_resolution_date=date(2026, 1, 31),
+            ),
+        ]
+
+        eac_analysis = EACAnalysis(
+            eac_cpi=Decimal("1041667"),
+            eac_spi=Decimal("1063830"),
+            eac_composite=Decimal("1107527"),
+            eac_typical=Decimal("1004000"),
+            eac_atypical=Decimal("1041667"),
+            eac_management=Decimal("1050000"),
+            eac_selected=Decimal("1041667"),
+            selection_rationale="CPI method selected - historical cost efficiency expected to continue",
+            eac_range_low=Decimal("1004000"),
+            eac_range_high=Decimal("1107527"),
+            eac_average=Decimal("1051448"),
+        )
+
+        return CPRFormat5Report(
+            program_name="Test Defense Program",
+            program_code="TDP-001",
+            contract_number="W12345-26-C-0001",
+            report_date=date(2026, 1, 15),
+            reporting_period="November 2025",
+            bac=Decimal("1000000"),
+            current_eac=Decimal("1041667"),
+            current_etc=Decimal("934667"),
+            current_vac=Decimal("-41667"),
+            cumulative_cpi=Decimal("0.96"),
+            cumulative_spi=Decimal("0.94"),
+            cumulative_tcpi=Decimal("1.00"),
+            percent_complete=Decimal("10.30"),
+            percent_spent=Decimal("10.70"),
+            period_rows=period_rows,
+            mr_rows=mr_rows,
+            current_mr=Decimal("85000"),
+            variance_explanations=variance_explanations,
+            eac_analysis=eac_analysis,
+            generated_at=date(2026, 1, 15),
+        )
+
+    # =========================================================================
+    # Format 1 PDF Tests
+    # =========================================================================
+
+    def test_generate_format1_pdf_returns_bytes(
+        self, pdf_generator: ReportPDFGenerator, sample_format1_report: CPRFormat1Report
+    ):
+        """Should return PDF as bytes."""
+        result = pdf_generator.generate_format1_pdf(sample_format1_report)
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_generate_format1_pdf_starts_with_pdf_header(
+        self, pdf_generator: ReportPDFGenerator, sample_format1_report: CPRFormat1Report
+    ):
+        """Should generate valid PDF with correct header."""
+        result = pdf_generator.generate_format1_pdf(sample_format1_report)
+
+        # PDF files start with %PDF-
+        assert result[:5] == b"%PDF-"
+
+    def test_generate_format1_pdf_is_valid(
+        self, pdf_generator: ReportPDFGenerator, sample_format1_report: CPRFormat1Report
+    ):
+        """Should generate valid PDF with content."""
+        result = pdf_generator.generate_format1_pdf(sample_format1_report)
+
+        # PDF text is compressed/encoded, so we check structure instead
+        assert result[:5] == b"%PDF-"
+        assert b"%%EOF" in result
+        # PDF should have substantial content
+        assert len(result) > 1000
+
+    def test_generate_format1_pdf_with_custom_config(
+        self, custom_pdf_generator: ReportPDFGenerator, sample_format1_report: CPRFormat1Report
+    ):
+        """Should respect custom configuration."""
+        result = custom_pdf_generator.generate_format1_pdf(sample_format1_report)
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+        assert result[:5] == b"%PDF-"
+
+    def test_generate_format1_pdf_with_empty_wbs_rows(self, pdf_generator: ReportPDFGenerator):
+        """Should handle report with no WBS rows."""
+        report = CPRFormat1Report(
+            program_name="Empty Program",
+            program_code="EMPTY-001",
+            contract_number=None,
+            reporting_period="January 2026",
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 1, 31),
+            report_date=date(2026, 2, 5),
+            total_bac=Decimal("0"),
+            total_bcws=Decimal("0"),
+            total_bcwp=Decimal("0"),
+            total_acwp=Decimal("0"),
+            total_cv=Decimal("0"),
+            total_sv=Decimal("0"),
+            total_cpi=None,
+            total_spi=None,
+            total_eac=None,
+            total_etc=None,
+            total_vac=None,
+            percent_complete=Decimal("0"),
+            percent_spent=Decimal("0"),
+            wbs_rows=[],
+            variance_notes=[],
+        )
+
+        result = pdf_generator.generate_format1_pdf(report)
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_generate_format1_pdf_with_null_values(self, pdf_generator: ReportPDFGenerator):
+        """Should handle null/None values gracefully."""
+        report = CPRFormat1Report(
+            program_name="Test Program",
+            program_code="TEST-001",
+            contract_number=None,
+            reporting_period="January 2026",
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 1, 31),
+            report_date=date(2026, 2, 5),
+            total_bac=Decimal("100000"),
+            total_bcws=Decimal("50000"),
+            total_bcwp=Decimal("0"),
+            total_acwp=Decimal("0"),
+            total_cv=Decimal("0"),
+            total_sv=Decimal("-50000"),
+            total_cpi=None,  # N/A when ACWP is 0
+            total_spi=None,  # N/A when BCWS is 0
+            total_eac=None,
+            total_etc=None,
+            total_vac=None,
+            percent_complete=Decimal("0"),
+            percent_spent=Decimal("0"),
+            wbs_rows=[],
+            variance_notes=[],
+        )
+
+        result = pdf_generator.generate_format1_pdf(report)
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    # =========================================================================
+    # Format 3 PDF Tests
+    # =========================================================================
+
+    def test_generate_format3_pdf_returns_bytes(
+        self, pdf_generator: ReportPDFGenerator, sample_format3_report: CPRFormat3Report
+    ):
+        """Should return PDF as bytes."""
+        result = pdf_generator.generate_format3_pdf(sample_format3_report)
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_generate_format3_pdf_starts_with_pdf_header(
+        self, pdf_generator: ReportPDFGenerator, sample_format3_report: CPRFormat3Report
+    ):
+        """Should generate valid PDF with correct header."""
+        result = pdf_generator.generate_format3_pdf(sample_format3_report)
+
+        assert result[:5] == b"%PDF-"
+
+    def test_generate_format3_pdf_is_valid(
+        self, pdf_generator: ReportPDFGenerator, sample_format3_report: CPRFormat3Report
+    ):
+        """Should generate valid PDF with content."""
+        result = pdf_generator.generate_format3_pdf(sample_format3_report)
+
+        # PDF text is compressed/encoded, so we check structure instead
+        assert result[:5] == b"%PDF-"
+        assert b"%%EOF" in result
+        # PDF should have substantial content
+        assert len(result) > 1000
+
+    def test_generate_format3_pdf_with_empty_time_rows(self, pdf_generator: ReportPDFGenerator):
+        """Should handle report with no time phase rows."""
+        report = CPRFormat3Report(
+            program_name="Empty Program",
+            program_code="EMPTY-001",
+            contract_number=None,
+            baseline_name="Empty Baseline",
+            baseline_version=1,
+            report_date=date(2026, 1, 15),
+            bac=Decimal("100000"),
+            current_period="",
+            percent_complete=Decimal("0"),
+            percent_spent=Decimal("0"),
+            total_bcws=Decimal("0"),
+            total_bcwp=Decimal("0"),
+            total_acwp=Decimal("0"),
+            total_sv=Decimal("0"),
+            total_cv=Decimal("0"),
+            eac=Decimal("100000"),
+            etc=Decimal("100000"),
+            vac=Decimal("0"),
+            cpi=None,
+            spi=None,
+            tcpi=None,
+            time_phase_rows=[],
+        )
+
+        result = pdf_generator.generate_format3_pdf(report)
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_generate_format3_pdf_with_schedule_info(
+        self, pdf_generator: ReportPDFGenerator, sample_format3_report: CPRFormat3Report
+    ):
+        """Should include schedule status in PDF."""
+        result = pdf_generator.generate_format3_pdf(sample_format3_report)
+
+        assert isinstance(result, bytes)
+        # The PDF should be larger when it includes time-phased data
+        assert len(result) > 1000
+
+    # =========================================================================
+    # Format 5 PDF Tests
+    # =========================================================================
+
+    def test_generate_format5_pdf_returns_bytes(
+        self, pdf_generator: ReportPDFGenerator, sample_format5_report: CPRFormat5Report
+    ):
+        """Should return PDF as bytes."""
+        result = pdf_generator.generate_format5_pdf(sample_format5_report)
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_generate_format5_pdf_starts_with_pdf_header(
+        self, pdf_generator: ReportPDFGenerator, sample_format5_report: CPRFormat5Report
+    ):
+        """Should generate valid PDF with correct header."""
+        result = pdf_generator.generate_format5_pdf(sample_format5_report)
+
+        assert result[:5] == b"%PDF-"
+
+    def test_generate_format5_pdf_with_eac_analysis(
+        self, pdf_generator: ReportPDFGenerator, sample_format5_report: CPRFormat5Report
+    ):
+        """Should include EAC analysis section."""
+        result = pdf_generator.generate_format5_pdf(sample_format5_report)
+
+        assert isinstance(result, bytes)
+        # PDF with EAC analysis should be substantial
+        assert len(result) > 2000
+
+    def test_generate_format5_pdf_with_mr_tracking(
+        self, pdf_generator: ReportPDFGenerator, sample_format5_report: CPRFormat5Report
+    ):
+        """Should include Management Reserve tracking."""
+        result = pdf_generator.generate_format5_pdf(sample_format5_report)
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_generate_format5_pdf_with_variance_explanations(
+        self, pdf_generator: ReportPDFGenerator, sample_format5_report: CPRFormat5Report
+    ):
+        """Should include variance explanations."""
+        result = pdf_generator.generate_format5_pdf(sample_format5_report)
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_generate_format5_pdf_without_optional_sections(
+        self, pdf_generator: ReportPDFGenerator
+    ):
+        """Should handle report without optional sections."""
+        report = CPRFormat5Report(
+            program_name="Minimal Program",
+            program_code="MIN-001",
+            contract_number=None,
+            report_date=date(2026, 1, 15),
+            reporting_period="January 2026",
+            bac=Decimal("100000"),
+            current_eac=Decimal("100000"),
+            current_etc=Decimal("100000"),
+            current_vac=Decimal("0"),
+            cumulative_cpi=None,
+            cumulative_spi=None,
+            cumulative_tcpi=None,
+            percent_complete=Decimal("0"),
+            percent_spent=Decimal("0"),
+            period_rows=[],
+            mr_rows=[],
+            current_mr=Decimal("0"),
+            variance_explanations=[],
+            eac_analysis=None,
+        )
+
+        result = pdf_generator.generate_format5_pdf(report)
+
+        assert isinstance(result, bytes)
+        assert len(result) > 0
+
+    def test_generate_format5_pdf_with_all_eac_methods(
+        self, pdf_generator: ReportPDFGenerator, sample_format5_report: CPRFormat5Report
+    ):
+        """Should include all 6 EAC methods when present."""
+        result = pdf_generator.generate_format5_pdf(sample_format5_report)
+
+        # The PDF should be substantial with all EAC methods
+        assert len(result) > 3000
+
+
+class TestPDFGeneratorHelperMethods:
+    """Tests for helper methods in ReportPDFGenerator."""
+
+    @pytest.fixture
+    def generator(self) -> ReportPDFGenerator:
+        """Create generator instance."""
+        return ReportPDFGenerator()
+
+    def test_format_currency_with_value(self, generator: ReportPDFGenerator):
+        """Should format decimal as currency."""
+        result = generator._format_currency(Decimal("1234567.89"))
+        assert result == "$1,234,568"
+
+    def test_format_currency_with_none(self, generator: ReportPDFGenerator):
+        """Should return N/A for None."""
+        result = generator._format_currency(None)
+        assert result == "N/A"
+
+    def test_format_currency_with_negative(self, generator: ReportPDFGenerator):
+        """Should format negative values correctly."""
+        result = generator._format_currency(Decimal("-50000"))
+        assert result == "$-50,000"
+
+    def test_format_percent_with_value(self, generator: ReportPDFGenerator):
+        """Should format decimal as percentage."""
+        result = generator._format_percent(Decimal("75.50"))
+        assert result == "75.5%"
+
+    def test_format_percent_with_none(self, generator: ReportPDFGenerator):
+        """Should return N/A for None."""
+        result = generator._format_percent(None)
+        assert result == "N/A"
+
+    def test_format_index_with_value(self, generator: ReportPDFGenerator):
+        """Should format index with 2 decimal places."""
+        result = generator._format_index(Decimal("0.9567"))
+        assert result == "0.96"
+
+    def test_format_index_with_none(self, generator: ReportPDFGenerator):
+        """Should return N/A for None."""
+        result = generator._format_index(None)
+        assert result == "N/A"
+
+    def test_format_date_with_value(self, generator: ReportPDFGenerator):
+        """Should format date as readable string."""
+        result = generator._format_date(date(2026, 1, 15))
+        assert result == "Jan 15, 2026"
+
+    def test_format_date_with_none(self, generator: ReportPDFGenerator):
+        """Should return N/A for None."""
+        result = generator._format_date(None)
+        assert result == "N/A"
+
+
+class TestPDFGeneratorOutputSize:
+    """Tests to ensure PDF generation produces reasonable output sizes."""
+
+    @pytest.fixture
+    def generator(self) -> ReportPDFGenerator:
+        """Create generator instance."""
+        return ReportPDFGenerator()
+
+    def test_format1_pdf_reasonable_size(self, generator: ReportPDFGenerator):
+        """Format 1 PDF should be within reasonable size range."""
+        report = CPRFormat1Report(
+            program_name="Size Test Program",
+            program_code="SIZE-001",
+            contract_number="CONTRACT-123",
+            reporting_period="January 2026",
+            period_start=date(2026, 1, 1),
+            period_end=date(2026, 1, 31),
+            report_date=date(2026, 2, 5),
+            total_bac=Decimal("1000000"),
+            total_bcws=Decimal("500000"),
+            total_bcwp=Decimal("450000"),
+            total_acwp=Decimal("480000"),
+            total_cv=Decimal("-30000"),
+            total_sv=Decimal("-50000"),
+            total_cpi=Decimal("0.94"),
+            total_spi=Decimal("0.90"),
+            total_eac=Decimal("1063830"),
+            total_etc=Decimal("583830"),
+            total_vac=Decimal("-63830"),
+            percent_complete=Decimal("45.00"),
+            percent_spent=Decimal("48.00"),
+            wbs_rows=[
+                WBSSummaryRow(
+                    wbs_code=f"1.{i}",
+                    wbs_name=f"Work Package {i}",
+                    level=2,
+                    is_control_account=i % 3 == 0,
+                    bac=Decimal("100000"),
+                    bcws=Decimal("50000"),
+                    bcwp=Decimal("45000"),
+                    acwp=Decimal("48000"),
+                    cv=Decimal("-3000"),
+                    sv=Decimal("-5000"),
+                    cpi=Decimal("0.94"),
+                    spi=Decimal("0.90"),
+                    eac=Decimal("106383"),
+                    etc=Decimal("58383"),
+                    vac=Decimal("-6383"),
+                )
+                for i in range(10)
+            ],
+            variance_notes=["Note 1", "Note 2", "Note 3"],
+        )
+
+        result = generator.generate_format1_pdf(report)
+
+        # PDF should be between 2KB and 500KB (reportlab generates compact PDFs)
+        assert 2000 < len(result) < 500000
+
+    def test_format3_pdf_reasonable_size(self, generator: ReportPDFGenerator):
+        """Format 3 PDF should be within reasonable size range."""
+        report = CPRFormat3Report(
+            program_name="Size Test Program",
+            program_code="SIZE-001",
+            contract_number="CONTRACT-123",
+            baseline_name="Test Baseline",
+            baseline_version=1,
+            report_date=date(2026, 1, 15),
+            bac=Decimal("1000000"),
+            current_period="December 2025",
+            percent_complete=Decimal("45.00"),
+            percent_spent=Decimal("48.00"),
+            total_bcws=Decimal("500000"),
+            total_bcwp=Decimal("450000"),
+            total_acwp=Decimal("480000"),
+            total_sv=Decimal("-50000"),
+            total_cv=Decimal("-30000"),
+            eac=Decimal("1063830"),
+            etc=Decimal("583830"),
+            vac=Decimal("-63830"),
+            cpi=Decimal("0.94"),
+            spi=Decimal("0.90"),
+            tcpi=Decimal("1.02"),
+            time_phase_rows=[
+                TimePhaseRow(
+                    period_name=f"Month {i}",
+                    period_start=date(2025, (i % 12) + 1, 1),
+                    period_end=date(2025, (i % 12) + 1, 28),
+                    bcws=Decimal("50000"),
+                    bcwp=Decimal("45000"),
+                    acwp=Decimal("48000"),
+                    cumulative_bcws=Decimal("50000") * (i + 1),
+                    cumulative_bcwp=Decimal("45000") * (i + 1),
+                    cumulative_acwp=Decimal("48000") * (i + 1),
+                    sv=Decimal("-5000"),
+                    cv=Decimal("-3000"),
+                )
+                for i in range(12)
+            ],
+        )
+
+        result = generator.generate_format3_pdf(report)
+
+        # PDF should be between 2KB and 500KB (reportlab generates compact PDFs)
+        assert 2000 < len(result) < 500000
+
+    def test_format5_pdf_reasonable_size(self, generator: ReportPDFGenerator):
+        """Format 5 PDF should be within reasonable size range."""
+        report = CPRFormat5Report(
+            program_name="Size Test Program",
+            program_code="SIZE-001",
+            contract_number="CONTRACT-123",
+            report_date=date(2026, 1, 15),
+            reporting_period="December 2025",
+            bac=Decimal("1000000"),
+            current_eac=Decimal("1063830"),
+            current_etc=Decimal("583830"),
+            current_vac=Decimal("-63830"),
+            cumulative_cpi=Decimal("0.94"),
+            cumulative_spi=Decimal("0.90"),
+            cumulative_tcpi=Decimal("1.02"),
+            percent_complete=Decimal("45.00"),
+            percent_spent=Decimal("48.00"),
+            period_rows=[
+                Format5PeriodRow(
+                    period_name=f"Month {i}",
+                    period_start=date(2025, (i % 12) + 1, 1),
+                    period_end=date(2025, (i % 12) + 1, 28),
+                    bcws=Decimal("50000"),
+                    bcwp=Decimal("45000"),
+                    acwp=Decimal("48000"),
+                    cumulative_bcws=Decimal("50000") * (i + 1),
+                    cumulative_bcwp=Decimal("45000") * (i + 1),
+                    cumulative_acwp=Decimal("48000") * (i + 1),
+                    period_sv=Decimal("-5000"),
+                    period_cv=Decimal("-3000"),
+                    cumulative_sv=Decimal("-5000") * (i + 1),
+                    cumulative_cv=Decimal("-3000") * (i + 1),
+                    sv_percent=Decimal("-10.00"),
+                    cv_percent=Decimal("-6.00"),
+                    spi=Decimal("0.90"),
+                    cpi=Decimal("0.94"),
+                    eac=Decimal("1063830"),
+                    etc=Decimal("583830"),
+                    vac=Decimal("-63830"),
+                    tcpi=Decimal("1.02"),
+                )
+                for i in range(12)
+            ],
+            mr_rows=[
+                ManagementReserveRow(
+                    period_name=f"Month {i}",
+                    beginning_mr=Decimal("100000") - Decimal("5000") * i,
+                    changes_in=Decimal("0"),
+                    changes_out=Decimal("5000"),
+                    ending_mr=Decimal("95000") - Decimal("5000") * i,
+                    reason=f"Released for unplanned work {i}",
+                )
+                for i in range(6)
+            ],
+            current_mr=Decimal("70000"),
+            variance_explanations=[
+                VarianceExplanation(
+                    wbs_code=f"1.{i}",
+                    wbs_name=f"Work Package {i}",
+                    variance_type="cost" if i % 2 == 0 else "schedule",
+                    variance_amount=Decimal("-15000"),
+                    variance_percent=Decimal("-12.5"),
+                    explanation=f"Explanation for variance {i}",
+                    corrective_action=f"Corrective action {i}",
+                    expected_resolution_date=date(2026, 2, 28),
+                )
+                for i in range(5)
+            ],
+            eac_analysis=EACAnalysis(
+                eac_cpi=Decimal("1063830"),
+                eac_spi=Decimal("1111111"),
+                eac_composite=Decimal("1180872"),
+                eac_typical=Decimal("1030000"),
+                eac_atypical=Decimal("1063830"),
+                eac_management=Decimal("1050000"),
+                eac_selected=Decimal("1063830"),
+                selection_rationale="CPI method selected",
+                eac_range_low=Decimal("1030000"),
+                eac_range_high=Decimal("1180872"),
+                eac_average=Decimal("1083274"),
+            ),
+        )
+
+        result = generator.generate_format5_pdf(report)
+
+        # PDF with all sections should be between 3KB and 1MB (reportlab generates compact PDFs)
+        assert 3000 < len(result) < 1000000


### PR DESCRIPTION
## Summary
- Add `ReportPDFGenerator` service with `PDFConfig` dataclass for customizable PDF generation
- Implement PDF export for all three CPR report formats (Format 1, 3, 5)
- Add API endpoints for PDF downloads with configurable orientation
- Include professional formatting with headers, footers, and classification banners

## Changes
### New Files
- `api/src/services/report_pdf_generator.py` - PDF generation service using reportlab
- `api/tests/unit/test_report_pdf_generator.py` - 32 comprehensive tests

### Modified Files
- `api/src/api/v1/endpoints/reports.py` - Add PDF export endpoints
- `api/src/services/cpr_format5_generator.py` - Minor lint fix

## New Endpoints
- `GET /api/v1/reports/cpr/{program_id}/pdf` - Format 1 (WBS Summary) PDF
- `GET /api/v1/reports/cpr-format3/{program_id}/pdf` - Format 3 (Baseline) PDF
- `GET /api/v1/reports/cpr-format5/{program_id}/pdf` - Format 5 (EVMS) PDF

## Test plan
- [x] All 32 new PDF generator tests pass
- [x] All 1516 unit tests pass
- [x] Ruff linting passes
- [x] Code formatting verified

🤖 Generated with [Claude Code](https://claude.com/claude-code)