### PR TITLE
feat(jira): add Jira integration models and migration

### DIFF
--- a/api/alembic/versions/008_jira_integration.py
+++ b/api/alembic/versions/008_jira_integration.py
@@ -1,0 +1,164 @@
+"""Week 10: Jira integration tables.
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-01-18
+
+Creates:
+- jira_integrations: Connection configuration per program
+- jira_mappings: WBS/Activity to Issue mappings
+- jira_sync_logs: Sync operation audit trail
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision = "008"
+down_revision = "007"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    # JiraIntegration table - stores connection configuration per program
+    op.create_table(
+        "jira_integrations",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "program_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("programs.id", ondelete="CASCADE"),
+            nullable=False,
+            unique=True,
+        ),
+        sa.Column("jira_url", sa.String(255), nullable=False),
+        sa.Column("project_key", sa.String(20), nullable=False),
+        sa.Column("email", sa.String(255), nullable=False),
+        sa.Column("api_token_encrypted", sa.LargeBinary, nullable=False),
+        sa.Column("sync_enabled", sa.Boolean, default=True, nullable=False),
+        sa.Column("last_sync_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("sync_status", sa.String(20), default="active", nullable=False),
+        sa.Column("epic_custom_field", sa.String(50), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_jira_integrations_program",
+        "jira_integrations",
+        ["program_id"],
+    )
+
+    # JiraMapping table - maps WBS/Activity to Jira issues
+    op.create_table(
+        "jira_mappings",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "integration_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("jira_integrations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("entity_type", sa.String(20), nullable=False),
+        sa.Column(
+            "wbs_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("wbs_elements.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column(
+            "activity_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("activities.id", ondelete="CASCADE"),
+            nullable=True,
+        ),
+        sa.Column("jira_issue_key", sa.String(50), nullable=False),
+        sa.Column("jira_issue_id", sa.String(50), nullable=True),
+        sa.Column("sync_direction", sa.String(20), default="to_jira", nullable=False),
+        sa.Column("last_synced_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("last_jira_updated", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_jira_mappings_integration",
+        "jira_mappings",
+        ["integration_id"],
+    )
+    op.create_index(
+        "ix_jira_mappings_wbs",
+        "jira_mappings",
+        ["wbs_id"],
+    )
+    op.create_index(
+        "ix_jira_mappings_activity",
+        "jira_mappings",
+        ["activity_id"],
+    )
+    op.create_index(
+        "ix_jira_mappings_issue_key",
+        "jira_mappings",
+        ["jira_issue_key"],
+    )
+
+    # Unique constraints for mappings
+    op.create_unique_constraint(
+        "uq_jira_mapping_wbs",
+        "jira_mappings",
+        ["integration_id", "entity_type", "wbs_id"],
+    )
+    op.create_unique_constraint(
+        "uq_jira_mapping_activity",
+        "jira_mappings",
+        ["integration_id", "entity_type", "activity_id"],
+    )
+    op.create_unique_constraint(
+        "uq_jira_mapping_issue",
+        "jira_mappings",
+        ["integration_id", "jira_issue_key"],
+    )
+
+    # JiraSyncLog table - audit trail for sync operations
+    op.create_table(
+        "jira_sync_logs",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "integration_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("jira_integrations.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column(
+            "mapping_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("jira_mappings.id", ondelete="SET NULL"),
+            nullable=True,
+        ),
+        sa.Column("sync_type", sa.String(20), nullable=False),
+        sa.Column("status", sa.String(20), nullable=False),
+        sa.Column("items_synced", sa.Integer, default=0, nullable=False),
+        sa.Column("error_message", sa.Text, nullable=True),
+        sa.Column("duration_ms", sa.Integer, nullable=True),
+        sa.Column("created_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("updated_at", sa.DateTime(timezone=True), server_default=sa.func.now()),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+    op.create_index(
+        "ix_jira_sync_logs_integration",
+        "jira_sync_logs",
+        ["integration_id"],
+    )
+    op.create_index(
+        "ix_jira_sync_logs_created",
+        "jira_sync_logs",
+        ["created_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("jira_sync_logs")
+    op.drop_table("jira_mappings")
+    op.drop_table("jira_integrations")

--- a/api/src/models/__init__.py
+++ b/api/src/models/__init__.py
@@ -32,6 +32,11 @@ from src.models.enums import (
     UserRole,
 )
 from src.models.evms_period import EVMSPeriod, EVMSPeriodData, PeriodStatus
+
+# Week 10: Jira integration models
+from src.models.jira_integration import JiraIntegration, JiraIntegrationStatus
+from src.models.jira_mapping import EntityType, JiraMapping, SyncDirection
+from src.models.jira_sync_log import JiraSyncLog, SyncStatus, SyncType
 from src.models.management_reserve_log import ManagementReserveLog
 from src.models.program import Program
 from src.models.report_audit import ReportAudit
@@ -49,8 +54,14 @@ __all__ = [
     "ConstraintType",
     "Dependency",
     "DependencyType",
+    # Week 10: Jira integration
+    "EntityType",
     "EVMSPeriod",
     "EVMSPeriodData",
+    "JiraIntegration",
+    "JiraIntegrationStatus",
+    "JiraMapping",
+    "JiraSyncLog",
     "LtreeType",
     "ManagementReserveLog",
     "PeriodStatus",
@@ -58,6 +69,9 @@ __all__ = [
     "ProgramStatus",
     "ReportAudit",
     "SoftDeleteMixin",
+    "SyncDirection",
+    "SyncStatus",
+    "SyncType",
     # Models
     "User",
     # Enums

--- a/api/src/models/activity.py
+++ b/api/src/models/activity.py
@@ -28,6 +28,7 @@ from src.models.enums import ConstraintType, EVMethod
 
 if TYPE_CHECKING:
     from src.models.dependency import Dependency
+    from src.models.jira_mapping import JiraMapping
     from src.models.program import Program
     from src.models.wbs import WBSElement
 
@@ -276,6 +277,14 @@ class Activity(Base):
         "Dependency",
         foreign_keys="Dependency.predecessor_id",
         back_populates="predecessor",
+        cascade="all, delete-orphan",
+    )
+
+    # Week 10: Jira mapping (Activity -> Issue)
+    jira_mapping: Mapped["JiraMapping | None"] = relationship(
+        "JiraMapping",
+        back_populates="activity",
+        uselist=False,
         cascade="all, delete-orphan",
     )
 

--- a/api/src/models/jira_integration.py
+++ b/api/src/models/jira_integration.py
@@ -1,0 +1,133 @@
+"""Jira integration model for storing connection configurations.
+
+Stores encrypted API tokens and tracks sync status per program.
+"""
+
+from datetime import datetime
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import Boolean, DateTime, ForeignKey, LargeBinary, String
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base
+
+if TYPE_CHECKING:
+    from src.models.jira_mapping import JiraMapping
+    from src.models.jira_sync_log import JiraSyncLog
+    from src.models.program import Program
+
+
+class JiraIntegrationStatus:
+    """Sync status values."""
+
+    ACTIVE = "active"
+    PAUSED = "paused"
+    ERROR = "error"
+    DISCONNECTED = "disconnected"
+
+
+class JiraIntegration(Base):
+    """
+    Jira integration configuration for a program.
+
+    Stores connection details and sync settings.
+    API tokens are encrypted at rest.
+
+    Attributes:
+        program_id: Associated program
+        jira_url: Jira Cloud URL
+        project_key: Target Jira project
+        email: User email for auth
+        api_token_encrypted: Encrypted API token
+        sync_enabled: Whether sync is active
+        last_sync_at: Last successful sync timestamp
+        sync_status: Current sync status
+        epic_custom_field: Custom field ID for epic name
+    """
+
+    __tablename__ = "jira_integrations"
+
+    program_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("programs.id", ondelete="CASCADE"),
+        nullable=False,
+        unique=True,
+        index=True,
+        comment="FK to parent program",
+    )
+
+    jira_url: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        comment="Jira Cloud URL (e.g., https://company.atlassian.net)",
+    )
+
+    project_key: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        comment="Target Jira project key",
+    )
+
+    email: Mapped[str] = mapped_column(
+        String(255),
+        nullable=False,
+        comment="User email for Jira authentication",
+    )
+
+    api_token_encrypted: Mapped[bytes] = mapped_column(
+        LargeBinary,
+        nullable=False,
+        comment="Encrypted Jira API token",
+    )
+
+    sync_enabled: Mapped[bool] = mapped_column(
+        Boolean,
+        default=True,
+        nullable=False,
+        comment="Whether bidirectional sync is active",
+    )
+
+    last_sync_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Timestamp of last successful sync",
+    )
+
+    sync_status: Mapped[str] = mapped_column(
+        String(20),
+        default=JiraIntegrationStatus.ACTIVE,
+        nullable=False,
+        comment="Current sync status (active, paused, error, disconnected)",
+    )
+
+    epic_custom_field: Mapped[str | None] = mapped_column(
+        String(50),
+        nullable=True,
+        comment="Custom field ID for Epic Name (varies by Jira instance)",
+    )
+
+    # Relationships
+    program: Mapped["Program"] = relationship(
+        "Program",
+        back_populates="jira_integration",
+    )
+
+    mappings: Mapped[list["JiraMapping"]] = relationship(
+        "JiraMapping",
+        back_populates="integration",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    sync_logs: Mapped[list["JiraSyncLog"]] = relationship(
+        "JiraSyncLog",
+        back_populates="integration",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="JiraSyncLog.created_at.desc()",
+    )
+
+    def __repr__(self) -> str:
+        return f"<JiraIntegration program={self.program_id} project={self.project_key}>"

--- a/api/src/models/jira_mapping.py
+++ b/api/src/models/jira_mapping.py
@@ -1,0 +1,165 @@
+"""Jira mapping model for WBS/Activity to Issue relationships.
+
+Tracks bidirectional mappings between Defense PM Tool entities
+and Jira issues/epics.
+"""
+
+from datetime import datetime
+from enum import Enum
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import DateTime, ForeignKey, String, UniqueConstraint
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base
+
+if TYPE_CHECKING:
+    from src.models.activity import Activity
+    from src.models.jira_integration import JiraIntegration
+    from src.models.wbs import WBSElement
+
+
+class SyncDirection(str, Enum):
+    """Sync direction for mappings."""
+
+    TO_JIRA = "to_jira"  # Push from Defense PM to Jira
+    FROM_JIRA = "from_jira"  # Pull from Jira to Defense PM
+    BIDIRECTIONAL = "bidirectional"  # Sync both ways
+
+
+class EntityType(str, Enum):
+    """Type of mapped entity."""
+
+    WBS = "wbs"
+    ACTIVITY = "activity"
+
+
+class JiraMapping(Base):
+    """
+    Mapping between Defense PM entities and Jira issues.
+
+    Supports:
+    - WBS -> Epic mappings
+    - Activity -> Issue mappings
+    - Bidirectional or one-way sync
+
+    Attributes:
+        integration_id: Parent Jira integration
+        entity_type: Type of Defense PM entity (wbs/activity)
+        wbs_id: WBS element ID (if type is wbs)
+        activity_id: Activity ID (if type is activity)
+        jira_issue_key: Jira issue key (e.g., "PROJ-123")
+        jira_issue_id: Jira issue ID (numeric)
+        sync_direction: Direction of sync
+        last_synced_at: Last successful sync
+        last_jira_updated: Last update timestamp from Jira
+    """
+
+    __tablename__ = "jira_mappings"
+    __table_args__ = (
+        # Ensure unique mapping per WBS entity
+        UniqueConstraint(
+            "integration_id",
+            "entity_type",
+            "wbs_id",
+            name="uq_jira_mapping_wbs",
+        ),
+        # Ensure unique mapping per Activity entity
+        UniqueConstraint(
+            "integration_id",
+            "entity_type",
+            "activity_id",
+            name="uq_jira_mapping_activity",
+        ),
+        # Ensure unique mapping per Jira issue
+        UniqueConstraint(
+            "integration_id",
+            "jira_issue_key",
+            name="uq_jira_mapping_issue",
+        ),
+        {"comment": "Mappings between Defense PM entities and Jira issues"},
+    )
+
+    integration_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("jira_integrations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="FK to parent Jira integration",
+    )
+
+    entity_type: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        comment="Type of Defense PM entity (wbs/activity)",
+    )
+
+    wbs_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("wbs_elements.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+        comment="FK to WBS element (if entity_type is wbs)",
+    )
+
+    activity_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("activities.id", ondelete="CASCADE"),
+        nullable=True,
+        index=True,
+        comment="FK to Activity (if entity_type is activity)",
+    )
+
+    jira_issue_key: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        index=True,
+        comment="Jira issue key (e.g., PROJ-123)",
+    )
+
+    jira_issue_id: Mapped[str | None] = mapped_column(
+        String(50),
+        nullable=True,
+        comment="Jira issue numeric ID",
+    )
+
+    sync_direction: Mapped[str] = mapped_column(
+        String(20),
+        default=SyncDirection.TO_JIRA.value,
+        nullable=False,
+        comment="Sync direction (to_jira, from_jira, bidirectional)",
+    )
+
+    last_synced_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Timestamp of last successful sync",
+    )
+
+    last_jira_updated: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+        comment="Last update timestamp from Jira API",
+    )
+
+    # Relationships
+    integration: Mapped["JiraIntegration"] = relationship(
+        "JiraIntegration",
+        back_populates="mappings",
+    )
+
+    wbs: Mapped["WBSElement | None"] = relationship(
+        "WBSElement",
+        back_populates="jira_mapping",
+    )
+
+    activity: Mapped["Activity | None"] = relationship(
+        "Activity",
+        back_populates="jira_mapping",
+    )
+
+    def __repr__(self) -> str:
+        entity = f"wbs={self.wbs_id}" if self.wbs_id else f"activity={self.activity_id}"
+        return f"<JiraMapping {entity} -> {self.jira_issue_key}>"

--- a/api/src/models/jira_sync_log.py
+++ b/api/src/models/jira_sync_log.py
@@ -1,0 +1,117 @@
+"""Jira sync log model for audit trail.
+
+Tracks all sync operations for debugging and compliance.
+"""
+
+from enum import Enum
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import ForeignKey, Integer, String, Text
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base
+
+if TYPE_CHECKING:
+    from src.models.jira_integration import JiraIntegration
+    from src.models.jira_mapping import JiraMapping
+
+
+class SyncType(str, Enum):
+    """Type of sync operation."""
+
+    PUSH = "push"  # Defense PM -> Jira
+    PULL = "pull"  # Jira -> Defense PM
+    WEBHOOK = "webhook"  # Triggered by Jira webhook
+    FULL = "full"  # Full bidirectional sync
+
+
+class SyncStatus(str, Enum):
+    """Status of sync operation."""
+
+    SUCCESS = "success"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
+class JiraSyncLog(Base):
+    """
+    Audit log for Jira sync operations.
+
+    Tracks:
+    - Sync type (push/pull/webhook)
+    - Success/failure status
+    - Number of items synced
+    - Error messages for debugging
+
+    Attributes:
+        integration_id: Associated Jira integration
+        mapping_id: Specific mapping (if single-entity sync)
+        sync_type: Type of sync operation
+        status: Success/failure status
+        items_synced: Count of synced items
+        error_message: Error details if failed
+        duration_ms: Sync duration in milliseconds
+    """
+
+    __tablename__ = "jira_sync_logs"
+
+    integration_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("jira_integrations.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="FK to parent Jira integration",
+    )
+
+    mapping_id: Mapped[UUID | None] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("jira_mappings.id", ondelete="SET NULL"),
+        nullable=True,
+        comment="FK to specific mapping (if single-entity sync)",
+    )
+
+    sync_type: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        comment="Type of sync operation (push/pull/webhook/full)",
+    )
+
+    status: Mapped[str] = mapped_column(
+        String(20),
+        nullable=False,
+        comment="Sync status (success/failed/partial)",
+    )
+
+    items_synced: Mapped[int] = mapped_column(
+        Integer,
+        default=0,
+        nullable=False,
+        comment="Number of items synced",
+    )
+
+    error_message: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        comment="Error details if sync failed",
+    )
+
+    duration_ms: Mapped[int | None] = mapped_column(
+        Integer,
+        nullable=True,
+        comment="Sync duration in milliseconds",
+    )
+
+    # Relationships
+    integration: Mapped["JiraIntegration"] = relationship(
+        "JiraIntegration",
+        back_populates="sync_logs",
+    )
+
+    mapping: Mapped["JiraMapping | None"] = relationship(
+        "JiraMapping",
+    )
+
+    def __repr__(self) -> str:
+        return f"<JiraSyncLog {self.sync_type} status={self.status}>"

--- a/api/src/models/program.py
+++ b/api/src/models/program.py
@@ -15,6 +15,7 @@ from src.models.enums import ProgramStatus
 
 if TYPE_CHECKING:
     from src.models.activity import Activity
+    from src.models.jira_integration import JiraIntegration
     from src.models.management_reserve_log import ManagementReserveLog
     from src.models.report_audit import ReportAudit
     from src.models.user import User
@@ -161,6 +162,14 @@ class Program(Base):
         back_populates="program",
         cascade="all, delete-orphan",
         lazy="selectin",
+    )
+
+    # Week 10: Jira integration
+    jira_integration: Mapped["JiraIntegration | None"] = relationship(
+        "JiraIntegration",
+        back_populates="program",
+        uselist=False,
+        cascade="all, delete-orphan",
     )
 
     # Table-level configuration

--- a/api/src/models/wbs.py
+++ b/api/src/models/wbs.py
@@ -21,6 +21,7 @@ from sqlalchemy.types import UserDefinedType
 
 if TYPE_CHECKING:
     from src.models.activity import Activity
+    from src.models.jira_mapping import JiraMapping
     from src.models.program import Program
     from src.models.variance_explanation import VarianceExplanation
 
@@ -193,6 +194,14 @@ class WBSElement(Base):
         back_populates="wbs",
         cascade="all, delete-orphan",
         lazy="selectin",
+    )
+
+    # Week 10: Jira mapping (WBS -> Epic)
+    jira_mapping: Mapped["JiraMapping | None"] = relationship(
+        "JiraMapping",
+        back_populates="wbs",
+        uselist=False,
+        cascade="all, delete-orphan",
     )
 
     # Table-level configuration


### PR DESCRIPTION
## Summary

- Adds database models for Week 10 Jira integration
- Creates migration 008 with all tables and indexes
- Updates Program, WBSElement, Activity models with relationships

## Models Created

### JiraIntegration
Stores connection configuration per program:
- `jira_url`: Jira Cloud URL
- `project_key`: Target Jira project
- `email`: User email for auth
- `api_token_encrypted`: Encrypted API token (LargeBinary)
- `sync_enabled`: Whether sync is active
- `sync_status`: Current status (active/paused/error/disconnected)
- `epic_custom_field`: Custom field ID for Epic Name

### JiraMapping
Maps Defense PM entities to Jira issues:
- `entity_type`: Type of entity (wbs/activity)
- `wbs_id` / `activity_id`: Foreign keys to entities
- `jira_issue_key`: Jira issue key (e.g., "PROJ-123")
- `sync_direction`: to_jira, from_jira, or bidirectional
- Unique constraints for entity and issue mappings

### JiraSyncLog
Audit trail for sync operations:
- `sync_type`: push, pull, webhook, full
- `status`: success, failed, partial
- `items_synced`: Count of synced items
- `error_message`: Error details if failed
- `duration_ms`: Sync duration in milliseconds

## Migration 008
- Creates `jira_integrations`, `jira_mappings`, `jira_sync_logs` tables
- Adds foreign keys with CASCADE delete
- Creates indexes for efficient queries
- Adds unique constraints for mapping integrity

## Test plan
- [x] Run ruff check and format
- [x] Run mypy type checking
- [x] Run unit tests (1670 passed)
- [x] Verify model relationships compile correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)