### PR TITLE
Feature: WBS to Jira Epic Sync

### DIFF
--- a/api/src/repositories/__init__.py
+++ b/api/src/repositories/__init__.py
@@ -3,6 +3,9 @@
 from src.repositories.activity import ActivityRepository
 from src.repositories.dependency import DependencyRepository
 from src.repositories.evms_period import EVMSPeriodDataRepository, EVMSPeriodRepository
+from src.repositories.jira_integration import JiraIntegrationRepository
+from src.repositories.jira_mapping import JiraMappingRepository
+from src.repositories.jira_sync_log import JiraSyncLogRepository
 from src.repositories.program import ProgramRepository
 from src.repositories.wbs import WBSElementRepository
 
@@ -11,6 +14,9 @@ __all__ = [
     "DependencyRepository",
     "EVMSPeriodDataRepository",
     "EVMSPeriodRepository",
+    "JiraIntegrationRepository",
+    "JiraMappingRepository",
+    "JiraSyncLogRepository",
     "ProgramRepository",
     "WBSElementRepository",
 ]

--- a/api/src/repositories/jira_integration.py
+++ b/api/src/repositories/jira_integration.py
@@ -1,0 +1,75 @@
+"""Repository for JiraIntegration model."""
+
+from uuid import UUID
+
+from sqlalchemy import select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.jira_integration import JiraIntegration
+from src.repositories.base import BaseRepository
+
+
+class JiraIntegrationRepository(BaseRepository[JiraIntegration]):
+    """Repository for Jira integration CRUD operations."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize with JiraIntegration model."""
+        super().__init__(JiraIntegration, session)
+
+    async def get_by_program(
+        self,
+        program_id: UUID,
+        include_deleted: bool = False,
+    ) -> JiraIntegration | None:
+        """Get Jira integration for a program.
+
+        Args:
+            program_id: Program UUID
+            include_deleted: Whether to include soft-deleted records
+
+        Returns:
+            JiraIntegration or None if not found
+        """
+        query = select(JiraIntegration).where(JiraIntegration.program_id == program_id)
+        query = self._apply_soft_delete_filter(query, include_deleted)
+
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()
+
+    async def get_active_integrations(self) -> list[JiraIntegration]:
+        """Get all active (sync_enabled=True) integrations.
+
+        Returns:
+            List of active JiraIntegration instances
+        """
+        query = (
+            select(JiraIntegration)
+            .where(
+                JiraIntegration.sync_enabled.is_(True),
+                JiraIntegration.deleted_at.is_(None),
+            )
+            .order_by(JiraIntegration.created_at)
+        )
+
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def get_by_status(
+        self,
+        status: str,
+        include_deleted: bool = False,
+    ) -> list[JiraIntegration]:
+        """Get integrations by sync status.
+
+        Args:
+            status: Sync status value (active, paused, error, disconnected)
+            include_deleted: Whether to include soft-deleted records
+
+        Returns:
+            List of matching JiraIntegration instances
+        """
+        query = select(JiraIntegration).where(JiraIntegration.sync_status == status)
+        query = self._apply_soft_delete_filter(query, include_deleted)
+
+        result = await self.session.execute(query)
+        return list(result.scalars().all())

--- a/api/src/repositories/jira_mapping.py
+++ b/api/src/repositories/jira_mapping.py
@@ -1,0 +1,180 @@
+"""Repository for JiraMapping model."""
+
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.jira_mapping import JiraMapping
+from src.models.wbs import WBSElement
+from src.repositories.base import BaseRepository
+
+
+class JiraMappingRepository(BaseRepository[JiraMapping]):
+    """Repository for Jira mapping CRUD operations."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize with JiraMapping model."""
+        super().__init__(JiraMapping, session)
+
+    async def get_by_wbs(
+        self,
+        integration_id: UUID,
+        wbs_id: UUID,
+        include_deleted: bool = False,
+    ) -> JiraMapping | None:
+        """Get mapping for a WBS element.
+
+        Args:
+            integration_id: Jira integration UUID
+            wbs_id: WBS element UUID
+            include_deleted: Whether to include soft-deleted records
+
+        Returns:
+            JiraMapping or None if not found
+        """
+        query = select(JiraMapping).where(
+            JiraMapping.integration_id == integration_id,
+            JiraMapping.wbs_id == wbs_id,
+        )
+        query = self._apply_soft_delete_filter(query, include_deleted)
+
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()
+
+    async def get_by_activity(
+        self,
+        integration_id: UUID,
+        activity_id: UUID,
+        include_deleted: bool = False,
+    ) -> JiraMapping | None:
+        """Get mapping for an activity.
+
+        Args:
+            integration_id: Jira integration UUID
+            activity_id: Activity UUID
+            include_deleted: Whether to include soft-deleted records
+
+        Returns:
+            JiraMapping or None if not found
+        """
+        query = select(JiraMapping).where(
+            JiraMapping.integration_id == integration_id,
+            JiraMapping.activity_id == activity_id,
+        )
+        query = self._apply_soft_delete_filter(query, include_deleted)
+
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()
+
+    async def get_by_integration(
+        self,
+        integration_id: UUID,
+        entity_type: str | None = None,
+        include_deleted: bool = False,
+    ) -> list[JiraMapping]:
+        """Get all mappings for an integration.
+
+        Args:
+            integration_id: Jira integration UUID
+            entity_type: Optional entity type filter ('wbs' or 'activity')
+            include_deleted: Whether to include soft-deleted records
+
+        Returns:
+            List of JiraMapping instances
+        """
+        query = select(JiraMapping).where(JiraMapping.integration_id == integration_id)
+
+        if entity_type:
+            query = query.where(JiraMapping.entity_type == entity_type)
+
+        query = self._apply_soft_delete_filter(query, include_deleted)
+        query = query.order_by(JiraMapping.created_at)
+
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def get_by_jira_key(
+        self,
+        integration_id: UUID,
+        jira_issue_key: str,
+        include_deleted: bool = False,
+    ) -> JiraMapping | None:
+        """Get mapping by Jira issue key.
+
+        Args:
+            integration_id: Jira integration UUID
+            jira_issue_key: Jira issue key (e.g., 'PROJ-123')
+            include_deleted: Whether to include soft-deleted records
+
+        Returns:
+            JiraMapping or None if not found
+        """
+        query = select(JiraMapping).where(
+            JiraMapping.integration_id == integration_id,
+            JiraMapping.jira_issue_key == jira_issue_key,
+        )
+        query = self._apply_soft_delete_filter(query, include_deleted)
+
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()
+
+    async def get_unmapped_wbs(
+        self,
+        integration_id: UUID,
+        program_id: UUID,
+    ) -> list[UUID]:
+        """Get WBS element IDs that are not yet mapped.
+
+        Args:
+            integration_id: Jira integration UUID
+            program_id: Program UUID
+
+        Returns:
+            List of unmapped WBS element UUIDs
+        """
+        # Get all WBS IDs for the program
+        wbs_query = select(WBSElement.id).where(
+            WBSElement.program_id == program_id,
+            WBSElement.deleted_at.is_(None),
+        )
+
+        # Get mapped WBS IDs
+        mapped_query = select(JiraMapping.wbs_id).where(
+            JiraMapping.integration_id == integration_id,
+            JiraMapping.wbs_id.isnot(None),
+            JiraMapping.deleted_at.is_(None),
+        )
+
+        # Find unmapped
+        all_wbs = await self.session.execute(wbs_query)
+        all_wbs_ids = set(all_wbs.scalars().all())
+
+        mapped = await self.session.execute(mapped_query)
+        mapped_ids = set(mapped.scalars().all())
+
+        return list(all_wbs_ids - mapped_ids)
+
+    async def count_by_entity_type(
+        self,
+        integration_id: UUID,
+    ) -> dict[str, int]:
+        """Count mappings by entity type.
+
+        Args:
+            integration_id: Jira integration UUID
+
+        Returns:
+            Dict with counts by entity type
+        """
+        query = (
+            select(JiraMapping.entity_type, func.count(JiraMapping.id))
+            .where(
+                JiraMapping.integration_id == integration_id,
+                JiraMapping.deleted_at.is_(None),
+            )
+            .group_by(JiraMapping.entity_type)
+        )
+
+        result = await self.session.execute(query)
+        return {row[0]: row[1] for row in result.all()}

--- a/api/src/repositories/jira_sync_log.py
+++ b/api/src/repositories/jira_sync_log.py
@@ -1,0 +1,223 @@
+"""Repository for JiraSyncLog model."""
+
+from datetime import datetime
+from uuid import UUID
+
+from sqlalchemy import func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.jira_sync_log import JiraSyncLog
+from src.repositories.base import BaseRepository
+
+
+class JiraSyncLogRepository(BaseRepository[JiraSyncLog]):
+    """Repository for Jira sync log operations."""
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize with JiraSyncLog model."""
+        super().__init__(JiraSyncLog, session)
+
+    async def get_by_integration(
+        self,
+        integration_id: UUID,
+        limit: int = 100,
+    ) -> list[JiraSyncLog]:
+        """Get sync logs for an integration.
+
+        Args:
+            integration_id: Jira integration UUID
+            limit: Maximum number of records to return
+
+        Returns:
+            List of JiraSyncLog instances ordered by created_at desc
+        """
+        query = (
+            select(JiraSyncLog)
+            .where(JiraSyncLog.integration_id == integration_id)
+            .order_by(JiraSyncLog.created_at.desc())
+            .limit(limit)
+        )
+
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def get_by_mapping(
+        self,
+        mapping_id: UUID,
+        limit: int = 50,
+    ) -> list[JiraSyncLog]:
+        """Get sync logs for a specific mapping.
+
+        Args:
+            mapping_id: Jira mapping UUID
+            limit: Maximum number of records to return
+
+        Returns:
+            List of JiraSyncLog instances
+        """
+        query = (
+            select(JiraSyncLog)
+            .where(JiraSyncLog.mapping_id == mapping_id)
+            .order_by(JiraSyncLog.created_at.desc())
+            .limit(limit)
+        )
+
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def get_latest(
+        self,
+        integration_id: UUID,
+    ) -> JiraSyncLog | None:
+        """Get the most recent sync log for an integration.
+
+        Args:
+            integration_id: Jira integration UUID
+
+        Returns:
+            Most recent JiraSyncLog or None
+        """
+        query = (
+            select(JiraSyncLog)
+            .where(JiraSyncLog.integration_id == integration_id)
+            .order_by(JiraSyncLog.created_at.desc())
+            .limit(1)
+        )
+
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()
+
+    async def get_by_status(
+        self,
+        integration_id: UUID,
+        status: str,
+        limit: int = 50,
+    ) -> list[JiraSyncLog]:
+        """Get sync logs by status.
+
+        Args:
+            integration_id: Jira integration UUID
+            status: Sync status (success, failed, partial)
+            limit: Maximum number of records to return
+
+        Returns:
+            List of JiraSyncLog instances
+        """
+        query = (
+            select(JiraSyncLog)
+            .where(
+                JiraSyncLog.integration_id == integration_id,
+                JiraSyncLog.status == status,
+            )
+            .order_by(JiraSyncLog.created_at.desc())
+            .limit(limit)
+        )
+
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def get_by_date_range(
+        self,
+        integration_id: UUID,
+        start_date: datetime,
+        end_date: datetime,
+    ) -> list[JiraSyncLog]:
+        """Get sync logs within a date range.
+
+        Args:
+            integration_id: Jira integration UUID
+            start_date: Start of date range
+            end_date: End of date range
+
+        Returns:
+            List of JiraSyncLog instances
+        """
+        query = (
+            select(JiraSyncLog)
+            .where(
+                JiraSyncLog.integration_id == integration_id,
+                JiraSyncLog.created_at >= start_date,
+                JiraSyncLog.created_at <= end_date,
+            )
+            .order_by(JiraSyncLog.created_at.desc())
+        )
+
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def get_stats(
+        self,
+        integration_id: UUID,
+    ) -> dict[str, int]:
+        """Get sync statistics for an integration.
+
+        Args:
+            integration_id: Jira integration UUID
+
+        Returns:
+            Dict with total_syncs, total_items, success_count, failed_count
+        """
+        # Count by status
+        status_query = (
+            select(JiraSyncLog.status, func.count(JiraSyncLog.id))
+            .where(JiraSyncLog.integration_id == integration_id)
+            .group_by(JiraSyncLog.status)
+        )
+        status_result = await self.session.execute(status_query)
+        status_counts: dict[str, int] = {row[0]: row[1] for row in status_result.all()}
+
+        # Total items synced
+        items_query = select(func.sum(JiraSyncLog.items_synced)).where(
+            JiraSyncLog.integration_id == integration_id
+        )
+        items_result = await self.session.execute(items_query)
+        total_items = items_result.scalar_one() or 0
+
+        return {
+            "total_syncs": sum(status_counts.values()),
+            "total_items": total_items,
+            "success_count": status_counts.get("success", 0),
+            "failed_count": status_counts.get("failed", 0),
+            "partial_count": status_counts.get("partial", 0),
+        }
+
+    async def cleanup_old_logs(
+        self,
+        integration_id: UUID,
+        keep_count: int = 1000,
+    ) -> int:
+        """Delete old sync logs, keeping the most recent ones.
+
+        Args:
+            integration_id: Jira integration UUID
+            keep_count: Number of recent logs to keep
+
+        Returns:
+            Number of deleted logs
+        """
+        # Get IDs of logs to keep
+        keep_query = (
+            select(JiraSyncLog.id)
+            .where(JiraSyncLog.integration_id == integration_id)
+            .order_by(JiraSyncLog.created_at.desc())
+            .limit(keep_count)
+        )
+        keep_result = await self.session.execute(keep_query)
+        keep_ids = set(keep_result.scalars().all())
+
+        # Get all logs for integration
+        all_query = select(JiraSyncLog).where(JiraSyncLog.integration_id == integration_id)
+        all_result = await self.session.execute(all_query)
+        all_logs = list(all_result.scalars().all())
+
+        # Delete logs not in keep set
+        deleted_count = 0
+        for log in all_logs:
+            if log.id not in keep_ids:
+                await self.session.delete(log)
+                deleted_count += 1
+
+        if deleted_count > 0:
+            await self.session.flush()
+
+        return deleted_count

--- a/api/src/services/__init__.py
+++ b/api/src/services/__init__.py
@@ -2,8 +2,12 @@
 
 from src.services.cpm import CPMEngine
 from src.services.evms import EVMSCalculator
+from src.services.jira_client import JiraClient
+from src.services.jira_wbs_sync import WBSSyncService
 
 __all__ = [
     "CPMEngine",
     "EVMSCalculator",
+    "JiraClient",
+    "WBSSyncService",
 ]

--- a/api/src/services/jira_wbs_sync.py
+++ b/api/src/services/jira_wbs_sync.py
@@ -1,0 +1,700 @@
+"""WBS to Jira Epic synchronization service.
+
+Provides bidirectional sync between WBS elements (levels 1-2) and Jira Epics.
+Supports:
+- Push WBS elements to Jira as Epics
+- Pull Epic updates from Jira
+- Conflict resolution (last-write-wins)
+- Comprehensive audit logging
+
+Usage:
+    service = WBSSyncService(
+        jira_client=client,
+        integration_repo=integration_repo,
+        mapping_repo=mapping_repo,
+        sync_log_repo=sync_log_repo,
+        wbs_repo=wbs_repo,
+    )
+    result = await service.sync_wbs_to_jira(integration_id, wbs_ids)
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from src.models.jira_mapping import EntityType, SyncDirection
+from src.models.jira_sync_log import SyncStatus, SyncType
+from src.services.jira_client import JiraClient, JiraSyncError
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from src.models.jira_integration import JiraIntegration
+    from src.models.jira_mapping import JiraMapping
+    from src.models.wbs import WBSElement
+    from src.repositories.jira_integration import JiraIntegrationRepository
+    from src.repositories.jira_mapping import JiraMappingRepository
+    from src.repositories.jira_sync_log import JiraSyncLogRepository
+    from src.repositories.wbs import WBSElementRepository
+
+
+logger = structlog.get_logger(__name__)
+
+
+class WBSSyncError(Exception):
+    """Base exception for WBS sync operations."""
+
+    def __init__(self, message: str, details: dict[str, Any] | None = None):
+        self.message = message
+        self.details = details or {}
+        super().__init__(message)
+
+
+class IntegrationNotFoundError(WBSSyncError):
+    """Jira integration not found."""
+
+    pass
+
+
+class SyncDisabledError(WBSSyncError):
+    """Sync is disabled for this integration."""
+
+    pass
+
+
+@dataclass
+class SyncResult:
+    """Result of a sync operation."""
+
+    success: bool
+    items_synced: int
+    items_failed: int
+    errors: list[str] = field(default_factory=list)
+    created_mappings: list[UUID] = field(default_factory=list)
+    updated_mappings: list[UUID] = field(default_factory=list)
+    duration_ms: int = 0
+
+
+@dataclass
+class WBSSyncItem:
+    """Represents a WBS element to sync with its mapping status."""
+
+    wbs: WBSElement
+    mapping: JiraMapping | None
+    action: str  # "create", "update", "skip"
+    jira_key: str | None = None
+    error: str | None = None
+
+
+class WBSSyncService:
+    """
+    Service for syncing WBS elements to Jira Epics.
+
+    Handles:
+    - WBS level 1-2 → Epic creation
+    - Bidirectional updates
+    - Conflict resolution (last-write-wins by timestamp)
+    - Audit logging for compliance
+
+    Attributes:
+        jira_client: Jira API client
+        integration_repo: Repository for Jira integrations
+        mapping_repo: Repository for entity mappings
+        sync_log_repo: Repository for sync audit logs
+        wbs_repo: Repository for WBS elements
+        max_wbs_level: Maximum WBS level to sync (default 2)
+    """
+
+    MAX_WBS_LEVEL = 2  # Only sync levels 1-2 as Epics
+
+    def __init__(
+        self,
+        jira_client: JiraClient,
+        integration_repo: JiraIntegrationRepository,
+        mapping_repo: JiraMappingRepository,
+        sync_log_repo: JiraSyncLogRepository,
+        wbs_repo: WBSElementRepository,
+    ) -> None:
+        """Initialize WBS sync service.
+
+        Args:
+            jira_client: Jira API client instance
+            integration_repo: Repository for Jira integrations
+            mapping_repo: Repository for entity mappings
+            sync_log_repo: Repository for sync audit logs
+            wbs_repo: Repository for WBS elements
+        """
+        self.jira_client = jira_client
+        self.integration_repo = integration_repo
+        self.mapping_repo = mapping_repo
+        self.sync_log_repo = sync_log_repo
+        self.wbs_repo = wbs_repo
+
+    async def sync_wbs_to_jira(
+        self,
+        integration_id: UUID,
+        wbs_ids: list[UUID] | None = None,
+    ) -> SyncResult:
+        """Sync WBS elements to Jira as Epics.
+
+        Creates new Epics for unmapped WBS elements and updates
+        existing mappings when WBS data has changed.
+
+        Args:
+            integration_id: Jira integration UUID
+            wbs_ids: Optional list of specific WBS IDs to sync.
+                     If None, syncs all eligible WBS elements.
+
+        Returns:
+            SyncResult with sync statistics
+
+        Raises:
+            IntegrationNotFoundError: If integration doesn't exist
+            SyncDisabledError: If sync is disabled
+            WBSSyncError: If sync fails
+        """
+        start_time = time.time()
+        result = SyncResult(success=True, items_synced=0, items_failed=0)
+
+        try:
+            # Validate integration
+            integration = await self._get_integration(integration_id)
+
+            # Get WBS elements to sync
+            wbs_elements = await self._get_syncable_wbs(integration.program_id, wbs_ids)
+
+            if not wbs_elements:
+                logger.info(
+                    "wbs_sync_no_elements",
+                    integration_id=str(integration_id),
+                )
+                return result
+
+            # Prepare sync items with mapping status
+            sync_items = await self._prepare_sync_items(integration_id, wbs_elements)
+
+            # Process each item
+            for item in sync_items:
+                try:
+                    if item.action == "create":
+                        new_mapping = await self._create_epic(integration, item.wbs)
+                        result.created_mappings.append(new_mapping.id)
+                        result.items_synced += 1
+                    elif item.action == "update":
+                        updated_mapping = await self._update_epic(
+                            integration, item.wbs, item.mapping
+                        )
+                        if updated_mapping:
+                            result.updated_mappings.append(updated_mapping.id)
+                        result.items_synced += 1
+                    # Skip items are not counted
+                except JiraSyncError as e:
+                    item.error = str(e)
+                    result.errors.append(f"WBS {item.wbs.wbs_code}: {e}")
+                    result.items_failed += 1
+                    logger.warning(
+                        "wbs_sync_item_failed",
+                        wbs_id=str(item.wbs.id),
+                        wbs_code=item.wbs.wbs_code,
+                        error=str(e),
+                    )
+
+            # Determine overall status
+            if result.items_failed > 0 and result.items_synced > 0:
+                result.success = True  # Partial success
+                sync_status = SyncStatus.PARTIAL.value
+            elif result.items_failed > 0:
+                result.success = False
+                sync_status = SyncStatus.FAILED.value
+            else:
+                sync_status = SyncStatus.SUCCESS.value
+
+            # Calculate duration
+            result.duration_ms = int((time.time() - start_time) * 1000)
+
+            # Log sync operation
+            await self._log_sync(
+                integration_id=integration_id,
+                sync_type=SyncType.PUSH.value,
+                status=sync_status,
+                items_synced=result.items_synced,
+                error_message="; ".join(result.errors) if result.errors else None,
+                duration_ms=result.duration_ms,
+            )
+
+            # Update integration last_sync_at
+            if result.items_synced > 0:
+                await self._update_integration_sync_time(integration)
+
+            logger.info(
+                "wbs_sync_completed",
+                integration_id=str(integration_id),
+                items_synced=result.items_synced,
+                items_failed=result.items_failed,
+                duration_ms=result.duration_ms,
+            )
+
+            return result
+
+        except (IntegrationNotFoundError, SyncDisabledError):
+            raise
+        except Exception as e:
+            result.success = False
+            result.errors.append(str(e))
+            result.duration_ms = int((time.time() - start_time) * 1000)
+
+            await self._log_sync(
+                integration_id=integration_id,
+                sync_type=SyncType.PUSH.value,
+                status=SyncStatus.FAILED.value,
+                items_synced=0,
+                error_message=str(e),
+                duration_ms=result.duration_ms,
+            )
+
+            logger.error(
+                "wbs_sync_failed",
+                integration_id=str(integration_id),
+                error=str(e),
+            )
+            raise WBSSyncError(f"WBS sync failed: {e}") from e
+
+    async def pull_from_jira(
+        self,
+        integration_id: UUID,
+        mapping_ids: list[UUID] | None = None,
+    ) -> SyncResult:
+        """Pull updates from Jira Epics to WBS elements.
+
+        Fetches Epic data from Jira and updates corresponding WBS elements
+        when Jira has newer changes (conflict resolution: last-write-wins).
+
+        Args:
+            integration_id: Jira integration UUID
+            mapping_ids: Optional list of specific mapping IDs to pull.
+                        If None, pulls all mapped WBS elements.
+
+        Returns:
+            SyncResult with sync statistics
+
+        Raises:
+            IntegrationNotFoundError: If integration doesn't exist
+            SyncDisabledError: If sync is disabled
+            WBSSyncError: If pull fails
+        """
+        start_time = time.time()
+        result = SyncResult(success=True, items_synced=0, items_failed=0)
+
+        try:
+            integration = await self._get_integration(integration_id)
+
+            # Get mappings to pull
+            mappings = await self._get_mappings_for_pull(integration_id, mapping_ids)
+
+            if not mappings:
+                logger.info(
+                    "wbs_pull_no_mappings",
+                    integration_id=str(integration_id),
+                )
+                return result
+
+            # Process each mapping
+            for mapping in mappings:
+                try:
+                    updated = await self._pull_epic_to_wbs(integration, mapping)
+                    if updated:
+                        result.updated_mappings.append(mapping.id)
+                    result.items_synced += 1
+                except JiraSyncError as e:
+                    result.errors.append(f"Epic {mapping.jira_issue_key}: {e}")
+                    result.items_failed += 1
+                    logger.warning(
+                        "wbs_pull_item_failed",
+                        mapping_id=str(mapping.id),
+                        jira_key=mapping.jira_issue_key,
+                        error=str(e),
+                    )
+
+            # Determine overall status
+            if result.items_failed > 0 and result.items_synced > 0:
+                sync_status = SyncStatus.PARTIAL.value
+            elif result.items_failed > 0:
+                result.success = False
+                sync_status = SyncStatus.FAILED.value
+            else:
+                sync_status = SyncStatus.SUCCESS.value
+
+            result.duration_ms = int((time.time() - start_time) * 1000)
+
+            await self._log_sync(
+                integration_id=integration_id,
+                sync_type=SyncType.PULL.value,
+                status=sync_status,
+                items_synced=result.items_synced,
+                error_message="; ".join(result.errors) if result.errors else None,
+                duration_ms=result.duration_ms,
+            )
+
+            if result.items_synced > 0:
+                await self._update_integration_sync_time(integration)
+
+            logger.info(
+                "wbs_pull_completed",
+                integration_id=str(integration_id),
+                items_synced=result.items_synced,
+                items_failed=result.items_failed,
+                duration_ms=result.duration_ms,
+            )
+
+            return result
+
+        except (IntegrationNotFoundError, SyncDisabledError):
+            raise
+        except Exception as e:
+            result.success = False
+            result.errors.append(str(e))
+            result.duration_ms = int((time.time() - start_time) * 1000)
+
+            await self._log_sync(
+                integration_id=integration_id,
+                sync_type=SyncType.PULL.value,
+                status=SyncStatus.FAILED.value,
+                items_synced=0,
+                error_message=str(e),
+                duration_ms=result.duration_ms,
+            )
+
+            logger.error(
+                "wbs_pull_failed",
+                integration_id=str(integration_id),
+                error=str(e),
+            )
+            raise WBSSyncError(f"WBS pull failed: {e}") from e
+
+    async def _get_integration(self, integration_id: UUID) -> JiraIntegration:
+        """Get and validate Jira integration."""
+        integration = await self.integration_repo.get_by_id(integration_id)
+        if not integration:
+            raise IntegrationNotFoundError(
+                f"Integration {integration_id} not found",
+                {"integration_id": str(integration_id)},
+            )
+
+        if not integration.sync_enabled:
+            raise SyncDisabledError(
+                f"Sync is disabled for integration {integration_id}",
+                {"integration_id": str(integration_id)},
+            )
+
+        return integration
+
+    async def _get_syncable_wbs(
+        self,
+        program_id: UUID,
+        wbs_ids: list[UUID] | None = None,
+    ) -> list[WBSElement]:
+        """Get WBS elements eligible for sync (levels 1-2)."""
+        all_wbs = await self.wbs_repo.get_by_program(program_id)
+
+        # Filter to levels 1-2
+        eligible = [w for w in all_wbs if w.level <= self.MAX_WBS_LEVEL]
+
+        # Filter to specific IDs if provided
+        if wbs_ids:
+            eligible = [w for w in eligible if w.id in wbs_ids]
+
+        return eligible
+
+    async def _prepare_sync_items(
+        self,
+        integration_id: UUID,
+        wbs_elements: list[WBSElement],
+    ) -> list[WBSSyncItem]:
+        """Prepare sync items with mapping status and action."""
+        items = []
+
+        for wbs in wbs_elements:
+            mapping = await self.mapping_repo.get_by_wbs(integration_id, wbs.id)
+
+            if mapping is None:
+                # New WBS - create Epic
+                items.append(WBSSyncItem(wbs=wbs, mapping=None, action="create"))
+            elif mapping.sync_direction in (
+                SyncDirection.TO_JIRA.value,
+                SyncDirection.BIDIRECTIONAL.value,
+            ):
+                # Existing mapping - update Epic
+                items.append(WBSSyncItem(wbs=wbs, mapping=mapping, action="update"))
+            else:
+                # From Jira only - skip push
+                items.append(WBSSyncItem(wbs=wbs, mapping=mapping, action="skip"))
+
+        return items
+
+    async def _create_epic(
+        self,
+        integration: JiraIntegration,
+        wbs: WBSElement,
+    ) -> JiraMapping:
+        """Create a Jira Epic for a WBS element.
+
+        Args:
+            integration: Jira integration config
+            wbs: WBS element to create Epic for
+
+        Returns:
+            Created JiraMapping
+        """
+        epic_name = f"{wbs.wbs_code} - {wbs.name}"
+        description = self._build_epic_description(wbs)
+
+        # Create Epic in Jira
+        epic = await self.jira_client.create_epic(
+            project_key=integration.project_key,
+            name=epic_name,
+            summary=wbs.name,
+            description=description,
+            labels=["defense-pm-tool", f"wbs-level-{wbs.level}"],
+        )
+
+        # Create mapping record
+        mapping_data: dict[str, Any] = {
+            "integration_id": integration.id,
+            "entity_type": EntityType.WBS.value,
+            "wbs_id": wbs.id,
+            "jira_issue_key": epic.key,
+            "jira_issue_id": epic.id,
+            "sync_direction": SyncDirection.BIDIRECTIONAL.value,
+            "last_synced_at": datetime.now(UTC),
+            "last_jira_updated": epic.updated,
+        }
+
+        mapping = await self.mapping_repo.create(mapping_data)
+
+        logger.info(
+            "wbs_epic_created",
+            wbs_id=str(wbs.id),
+            wbs_code=wbs.wbs_code,
+            epic_key=epic.key,
+        )
+
+        return mapping
+
+    async def _update_epic(
+        self,
+        integration: JiraIntegration,
+        wbs: WBSElement,
+        mapping: JiraMapping | None,
+    ) -> JiraMapping | None:
+        """Update existing Jira Epic from WBS data.
+
+        Args:
+            integration: Jira integration config
+            wbs: WBS element with updated data
+            mapping: Existing mapping to update
+
+        Returns:
+            Updated JiraMapping or None if no update needed
+        """
+        if mapping is None:
+            return None
+
+        # Build updated fields
+        epic_name = f"{wbs.wbs_code} - {wbs.name}"
+        description = self._build_epic_description(wbs)
+
+        # Update Epic in Jira
+        await self.jira_client.update_issue(
+            issue_key=mapping.jira_issue_key,
+            summary=wbs.name,
+            description=description,
+            custom_fields={
+                # Epic Name field (may vary by Jira instance)
+                integration.epic_custom_field or "customfield_10011": epic_name,
+            },
+        )
+
+        # Update mapping record
+        mapping.last_synced_at = datetime.now(UTC)
+        await self.mapping_repo.update(mapping, {"last_synced_at": mapping.last_synced_at})
+
+        logger.info(
+            "wbs_epic_updated",
+            wbs_id=str(wbs.id),
+            wbs_code=wbs.wbs_code,
+            epic_key=mapping.jira_issue_key,
+        )
+
+        return mapping
+
+    def _build_epic_description(self, wbs: WBSElement) -> str:
+        """Build Epic description from WBS element.
+
+        Includes:
+        - WBS code and path
+        - Budget information if available
+        - Control account status
+        - Link back to Defense PM Tool
+        """
+        lines = [
+            f"*WBS Element:* {wbs.wbs_code}",
+            f"*Path:* {wbs.path}",
+            f"*Level:* {wbs.level}",
+        ]
+
+        if wbs.description:
+            lines.append(f"\n{wbs.description}")
+
+        if wbs.is_control_account:
+            lines.append("\n_This is a Control Account for EVMS tracking._")
+
+        if wbs.budget_at_completion and wbs.budget_at_completion > 0:
+            lines.append(f"\n*Budget at Completion:* ${wbs.budget_at_completion:,.2f}")
+
+        lines.append("\n---")
+        lines.append("_Synced from Defense PM Tool_")
+
+        return "\n".join(lines)
+
+    async def _get_mappings_for_pull(
+        self,
+        integration_id: UUID,
+        mapping_ids: list[UUID] | None = None,
+    ) -> list[JiraMapping]:
+        """Get mappings eligible for pull from Jira."""
+        all_mappings = await self.mapping_repo.get_by_integration(
+            integration_id, entity_type=EntityType.WBS.value
+        )
+
+        # Filter to specific IDs if provided
+        if mapping_ids:
+            all_mappings = [m for m in all_mappings if m.id in mapping_ids]
+
+        # Filter to mappings that allow pull
+        pullable = [
+            m
+            for m in all_mappings
+            if m.sync_direction
+            in (SyncDirection.FROM_JIRA.value, SyncDirection.BIDIRECTIONAL.value)
+        ]
+
+        return pullable
+
+    async def _pull_epic_to_wbs(
+        self,
+        _integration: JiraIntegration,
+        mapping: JiraMapping,
+    ) -> bool:
+        """Pull Epic data from Jira and update WBS if newer.
+
+        Uses last-write-wins conflict resolution based on timestamps.
+
+        Args:
+            _integration: Jira integration config (reserved for future use)
+            mapping: WBS-Epic mapping
+
+        Returns:
+            True if WBS was updated, False if no update needed
+        """
+        if mapping.wbs_id is None:
+            return False
+
+        # Fetch current Epic from Jira
+        epic = await self.jira_client.get_issue(mapping.jira_issue_key)
+
+        # Check if Jira has newer changes (conflict resolution)
+        if mapping.last_jira_updated and epic.updated <= mapping.last_jira_updated:
+            logger.debug(
+                "wbs_pull_skipped_no_changes",
+                mapping_id=str(mapping.id),
+                jira_key=mapping.jira_issue_key,
+            )
+            return False
+
+        # Get WBS element
+        wbs = await self.wbs_repo.get_by_id(mapping.wbs_id)
+        if not wbs:
+            logger.warning(
+                "wbs_pull_wbs_not_found",
+                mapping_id=str(mapping.id),
+                wbs_id=str(mapping.wbs_id),
+            )
+            return False
+
+        # Update WBS from Epic (only name/description for now)
+        # More fields could be synced based on requirements
+        update_data = {"name": epic.summary}
+
+        # Only update description if Epic has one
+        if epic.description:
+            # Parse description to extract original WBS description
+            # (exclude sync metadata)
+            desc_lines = epic.description.split("\n")
+            original_desc = []
+            for line in desc_lines:
+                if line.startswith("---") or line.startswith("_Synced from"):
+                    break
+                if not line.startswith("*WBS Element:*") and not line.startswith("*Path:*"):
+                    original_desc.append(line)
+            if original_desc:
+                update_data["description"] = "\n".join(original_desc).strip()
+
+        await self.wbs_repo.update(wbs, update_data)
+
+        # Update mapping timestamps
+        mapping.last_synced_at = datetime.now(UTC)
+        mapping.last_jira_updated = epic.updated
+        await self.mapping_repo.update(
+            mapping,
+            {
+                "last_synced_at": mapping.last_synced_at,
+                "last_jira_updated": mapping.last_jira_updated,
+            },
+        )
+
+        logger.info(
+            "wbs_pulled_from_jira",
+            wbs_id=str(wbs.id),
+            wbs_code=wbs.wbs_code,
+            epic_key=mapping.jira_issue_key,
+        )
+
+        return True
+
+    async def _log_sync(
+        self,
+        integration_id: UUID,
+        sync_type: str,
+        status: str,
+        items_synced: int,
+        error_message: str | None = None,
+        duration_ms: int | None = None,
+        mapping_id: UUID | None = None,
+    ) -> None:
+        """Log sync operation to audit trail."""
+        log_data: dict[str, Any] = {
+            "integration_id": integration_id,
+            "mapping_id": mapping_id,
+            "sync_type": sync_type,
+            "status": status,
+            "items_synced": items_synced,
+            "error_message": error_message,
+            "duration_ms": duration_ms,
+        }
+
+        await self.sync_log_repo.create(log_data)
+
+    async def _update_integration_sync_time(
+        self,
+        integration: JiraIntegration,
+    ) -> None:
+        """Update integration's last_sync_at timestamp."""
+        await self.integration_repo.update(
+            integration,
+            {"last_sync_at": datetime.now(UTC)},
+        )

--- a/api/tests/unit/test_wbs_sync_service.py
+++ b/api/tests/unit/test_wbs_sync_service.py
@@ -1,0 +1,1021 @@
+"""Unit tests for WBS to Jira Epic sync service.
+
+Tests the WBSSyncService with mocked repositories and Jira client.
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.services.jira_client import JiraEpicData, JiraIssueData, JiraSyncError
+from src.services.jira_wbs_sync import (
+    IntegrationNotFoundError,
+    SyncDisabledError,
+    SyncResult,
+    WBSSyncError,
+    WBSSyncItem,
+    WBSSyncService,
+)
+
+
+class TestSyncResult:
+    """Tests for SyncResult dataclass."""
+
+    def test_default_values(self):
+        """SyncResult should have sensible defaults."""
+        result = SyncResult(success=True, items_synced=0, items_failed=0)
+        assert result.success is True
+        assert result.items_synced == 0
+        assert result.items_failed == 0
+        assert result.errors == []
+        assert result.created_mappings == []
+        assert result.updated_mappings == []
+        assert result.duration_ms == 0
+
+    def test_with_values(self):
+        """SyncResult should store all values."""
+        mapping_id = uuid4()
+        result = SyncResult(
+            success=False,
+            items_synced=5,
+            items_failed=2,
+            errors=["Error 1", "Error 2"],
+            created_mappings=[mapping_id],
+            updated_mappings=[],
+            duration_ms=1500,
+        )
+        assert result.success is False
+        assert result.items_synced == 5
+        assert result.items_failed == 2
+        assert len(result.errors) == 2
+        assert mapping_id in result.created_mappings
+
+
+class TestWBSSyncItem:
+    """Tests for WBSSyncItem dataclass."""
+
+    def test_create_action(self):
+        """WBSSyncItem should track create action."""
+        mock_wbs = MagicMock()
+        item = WBSSyncItem(wbs=mock_wbs, mapping=None, action="create")
+        assert item.action == "create"
+        assert item.mapping is None
+        assert item.jira_key is None
+        assert item.error is None
+
+    def test_update_action(self):
+        """WBSSyncItem should track update action with mapping."""
+        mock_wbs = MagicMock()
+        mock_mapping = MagicMock()
+        item = WBSSyncItem(wbs=mock_wbs, mapping=mock_mapping, action="update", jira_key="PROJ-123")
+        assert item.action == "update"
+        assert item.mapping is mock_mapping
+        assert item.jira_key == "PROJ-123"
+
+
+class TestWBSSyncExceptions:
+    """Tests for custom WBS sync exceptions."""
+
+    def test_wbs_sync_error(self):
+        """WBSSyncError should store message and details."""
+        error = WBSSyncError("Sync failed", {"reason": "timeout"})
+        assert str(error) == "Sync failed"
+        assert error.message == "Sync failed"
+        assert error.details == {"reason": "timeout"}
+
+    def test_wbs_sync_error_default_details(self):
+        """WBSSyncError should default to empty details."""
+        error = WBSSyncError("Error")
+        assert error.details == {}
+
+    def test_integration_not_found_error(self):
+        """IntegrationNotFoundError should inherit from WBSSyncError."""
+        error = IntegrationNotFoundError("Not found")
+        assert isinstance(error, WBSSyncError)
+
+    def test_sync_disabled_error(self):
+        """SyncDisabledError should inherit from WBSSyncError."""
+        error = SyncDisabledError("Disabled")
+        assert isinstance(error, WBSSyncError)
+
+
+class TestWBSSyncServiceInit:
+    """Tests for WBSSyncService initialization."""
+
+    def test_init_stores_dependencies(self):
+        """Service should store all dependencies."""
+        mock_jira = MagicMock()
+        mock_integration_repo = MagicMock()
+        mock_mapping_repo = MagicMock()
+        mock_sync_log_repo = MagicMock()
+        mock_wbs_repo = MagicMock()
+
+        service = WBSSyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            wbs_repo=mock_wbs_repo,
+        )
+
+        assert service.jira_client is mock_jira
+        assert service.integration_repo is mock_integration_repo
+        assert service.mapping_repo is mock_mapping_repo
+        assert service.sync_log_repo is mock_sync_log_repo
+        assert service.wbs_repo is mock_wbs_repo
+
+    def test_max_wbs_level_constant(self):
+        """Service should have MAX_WBS_LEVEL constant."""
+        assert WBSSyncService.MAX_WBS_LEVEL == 2
+
+
+class TestWBSSyncServiceGetIntegration:
+    """Tests for _get_integration method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a WBSSyncService with mocked dependencies."""
+        mock_jira = MagicMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_wbs_repo = AsyncMock()
+
+        return WBSSyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            wbs_repo=mock_wbs_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_integration_success(self, service):
+        """Should return integration when found and enabled."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.sync_enabled = True
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        result = await service._get_integration(integration_id)
+
+        assert result is mock_integration
+        service.integration_repo.get_by_id.assert_called_once_with(integration_id)
+
+    @pytest.mark.asyncio
+    async def test_get_integration_not_found(self, service):
+        """Should raise IntegrationNotFoundError when not found."""
+        integration_id = uuid4()
+        service.integration_repo.get_by_id.return_value = None
+
+        with pytest.raises(IntegrationNotFoundError) as exc:
+            await service._get_integration(integration_id)
+
+        assert str(integration_id) in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_get_integration_disabled(self, service):
+        """Should raise SyncDisabledError when sync disabled."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.sync_enabled = False
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        with pytest.raises(SyncDisabledError) as exc:
+            await service._get_integration(integration_id)
+
+        assert "disabled" in str(exc.value).lower()
+
+
+class TestWBSSyncServiceGetSyncableWBS:
+    """Tests for _get_syncable_wbs method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a WBSSyncService with mocked dependencies."""
+        mock_jira = MagicMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_wbs_repo = AsyncMock()
+
+        return WBSSyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            wbs_repo=mock_wbs_repo,
+        )
+
+    @pytest.fixture
+    def sample_wbs_elements(self):
+        """Create sample WBS elements at different levels."""
+        elements = []
+        for i in range(5):
+            wbs = MagicMock()
+            wbs.id = uuid4()
+            wbs.level = i + 1  # Levels 1-5
+            wbs.wbs_code = f"1.{'1.' * i}1"
+            elements.append(wbs)
+        return elements
+
+    @pytest.mark.asyncio
+    async def test_filters_by_level(self, service, sample_wbs_elements):
+        """Should only return WBS elements at level 1-2."""
+        program_id = uuid4()
+        service.wbs_repo.get_by_program.return_value = sample_wbs_elements
+
+        result = await service._get_syncable_wbs(program_id)
+
+        assert len(result) == 2  # Only levels 1 and 2
+        assert all(w.level <= 2 for w in result)
+
+    @pytest.mark.asyncio
+    async def test_filters_by_specific_ids(self, service, sample_wbs_elements):
+        """Should filter to specific WBS IDs when provided."""
+        program_id = uuid4()
+        target_id = sample_wbs_elements[0].id
+        service.wbs_repo.get_by_program.return_value = sample_wbs_elements
+
+        result = await service._get_syncable_wbs(program_id, wbs_ids=[target_id])
+
+        assert len(result) == 1
+        assert result[0].id == target_id
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_no_eligible(self, service):
+        """Should return empty list when no eligible WBS elements."""
+        program_id = uuid4()
+        # Create only level 3+ elements
+        high_level_elements = []
+        for i in range(3, 6):
+            wbs = MagicMock()
+            wbs.id = uuid4()
+            wbs.level = i
+            high_level_elements.append(wbs)
+        service.wbs_repo.get_by_program.return_value = high_level_elements
+
+        result = await service._get_syncable_wbs(program_id)
+
+        assert len(result) == 0
+
+
+class TestWBSSyncServicePrepareSyncItems:
+    """Tests for _prepare_sync_items method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a WBSSyncService with mocked dependencies."""
+        mock_jira = MagicMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_wbs_repo = AsyncMock()
+
+        return WBSSyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            wbs_repo=mock_wbs_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_action_for_unmapped(self, service):
+        """Should assign 'create' action for unmapped WBS."""
+        integration_id = uuid4()
+        wbs = MagicMock()
+        wbs.id = uuid4()
+        service.mapping_repo.get_by_wbs.return_value = None
+
+        result = await service._prepare_sync_items(integration_id, [wbs])
+
+        assert len(result) == 1
+        assert result[0].action == "create"
+        assert result[0].mapping is None
+
+    @pytest.mark.asyncio
+    async def test_update_action_for_bidirectional_mapping(self, service):
+        """Should assign 'update' action for bidirectional mapping."""
+        integration_id = uuid4()
+        wbs = MagicMock()
+        wbs.id = uuid4()
+        mapping = MagicMock()
+        mapping.sync_direction = "bidirectional"
+        service.mapping_repo.get_by_wbs.return_value = mapping
+
+        result = await service._prepare_sync_items(integration_id, [wbs])
+
+        assert len(result) == 1
+        assert result[0].action == "update"
+        assert result[0].mapping is mapping
+
+    @pytest.mark.asyncio
+    async def test_update_action_for_to_jira_mapping(self, service):
+        """Should assign 'update' action for to_jira mapping."""
+        integration_id = uuid4()
+        wbs = MagicMock()
+        wbs.id = uuid4()
+        mapping = MagicMock()
+        mapping.sync_direction = "to_jira"
+        service.mapping_repo.get_by_wbs.return_value = mapping
+
+        result = await service._prepare_sync_items(integration_id, [wbs])
+
+        assert result[0].action == "update"
+
+    @pytest.mark.asyncio
+    async def test_skip_action_for_from_jira_mapping(self, service):
+        """Should assign 'skip' action for from_jira only mapping."""
+        integration_id = uuid4()
+        wbs = MagicMock()
+        wbs.id = uuid4()
+        mapping = MagicMock()
+        mapping.sync_direction = "from_jira"
+        service.mapping_repo.get_by_wbs.return_value = mapping
+
+        result = await service._prepare_sync_items(integration_id, [wbs])
+
+        assert result[0].action == "skip"
+
+
+class TestWBSSyncServiceBuildEpicDescription:
+    """Tests for _build_epic_description method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a WBSSyncService with mocked dependencies."""
+        mock_jira = MagicMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_wbs_repo = AsyncMock()
+
+        return WBSSyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            wbs_repo=mock_wbs_repo,
+        )
+
+    def test_includes_wbs_code_and_path(self, service):
+        """Description should include WBS code and path."""
+        wbs = MagicMock()
+        wbs.wbs_code = "1.2.3"
+        wbs.path = "1.2.3"
+        wbs.level = 3
+        wbs.description = None
+        wbs.is_control_account = False
+        wbs.budget_at_completion = Decimal("0.00")
+
+        result = service._build_epic_description(wbs)
+
+        assert "*WBS Element:* 1.2.3" in result
+        assert "*Path:* 1.2.3" in result
+        assert "*Level:* 3" in result
+
+    def test_includes_description_when_present(self, service):
+        """Description should include WBS description."""
+        wbs = MagicMock()
+        wbs.wbs_code = "1.1"
+        wbs.path = "1.1"
+        wbs.level = 2
+        wbs.description = "This is the subsystem design phase"
+        wbs.is_control_account = False
+        wbs.budget_at_completion = Decimal("0.00")
+
+        result = service._build_epic_description(wbs)
+
+        assert "This is the subsystem design phase" in result
+
+    def test_includes_control_account_indicator(self, service):
+        """Description should indicate if control account."""
+        wbs = MagicMock()
+        wbs.wbs_code = "1.1"
+        wbs.path = "1.1"
+        wbs.level = 2
+        wbs.description = None
+        wbs.is_control_account = True
+        wbs.budget_at_completion = Decimal("0.00")
+
+        result = service._build_epic_description(wbs)
+
+        assert "Control Account" in result
+
+    def test_includes_budget_when_present(self, service):
+        """Description should include budget when non-zero."""
+        wbs = MagicMock()
+        wbs.wbs_code = "1.1"
+        wbs.path = "1.1"
+        wbs.level = 2
+        wbs.description = None
+        wbs.is_control_account = False
+        wbs.budget_at_completion = Decimal("150000.00")
+
+        result = service._build_epic_description(wbs)
+
+        assert "$150,000.00" in result
+
+    def test_includes_sync_attribution(self, service):
+        """Description should include sync attribution."""
+        wbs = MagicMock()
+        wbs.wbs_code = "1.1"
+        wbs.path = "1.1"
+        wbs.level = 2
+        wbs.description = None
+        wbs.is_control_account = False
+        wbs.budget_at_completion = Decimal("0.00")
+
+        result = service._build_epic_description(wbs)
+
+        assert "Defense PM Tool" in result
+
+
+class TestWBSSyncServiceCreateEpic:
+    """Tests for _create_epic method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a WBSSyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_wbs_repo = AsyncMock()
+
+        return WBSSyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            wbs_repo=mock_wbs_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_creates_epic_in_jira(self, service):
+        """Should call jira_client.create_epic with correct params."""
+        integration = MagicMock()
+        integration.id = uuid4()
+        integration.project_key = "PROJ"
+
+        wbs = MagicMock()
+        wbs.id = uuid4()
+        wbs.wbs_code = "1.1"
+        wbs.name = "Design Phase"
+        wbs.path = "1.1"
+        wbs.level = 2
+        wbs.description = None
+        wbs.is_control_account = False
+        wbs.budget_at_completion = Decimal("0.00")
+
+        now = datetime.now(UTC)
+        epic_data = JiraEpicData(
+            key="PROJ-10",
+            id="10010",
+            name="1.1 - Design Phase",
+            summary="Design Phase",
+            description=None,
+            status="To Do",
+            created=now,
+            updated=now,
+        )
+        service.jira_client.create_epic.return_value = epic_data
+
+        mock_mapping = MagicMock()
+        mock_mapping.id = uuid4()
+        service.mapping_repo.create.return_value = mock_mapping
+
+        result = await service._create_epic(integration, wbs)
+
+        service.jira_client.create_epic.assert_called_once()
+        call_kwargs = service.jira_client.create_epic.call_args[1]
+        assert call_kwargs["project_key"] == "PROJ"
+        assert call_kwargs["name"] == "1.1 - Design Phase"
+        assert call_kwargs["summary"] == "Design Phase"
+        assert "defense-pm-tool" in call_kwargs["labels"]
+
+    @pytest.mark.asyncio
+    async def test_creates_mapping_record(self, service):
+        """Should create JiraMapping record."""
+        integration = MagicMock()
+        integration.id = uuid4()
+        integration.project_key = "PROJ"
+
+        wbs = MagicMock()
+        wbs.id = uuid4()
+        wbs.wbs_code = "1.1"
+        wbs.name = "Design Phase"
+        wbs.path = "1.1"
+        wbs.level = 2
+        wbs.description = None
+        wbs.is_control_account = False
+        wbs.budget_at_completion = Decimal("0.00")
+
+        now = datetime.now(UTC)
+        epic_data = JiraEpicData(
+            key="PROJ-10",
+            id="10010",
+            name="1.1 - Design Phase",
+            summary="Design Phase",
+            description=None,
+            status="To Do",
+            created=now,
+            updated=now,
+        )
+        service.jira_client.create_epic.return_value = epic_data
+
+        mock_mapping = MagicMock()
+        mock_mapping.id = uuid4()
+        service.mapping_repo.create.return_value = mock_mapping
+
+        result = await service._create_epic(integration, wbs)
+
+        assert result is mock_mapping
+        service.mapping_repo.create.assert_called_once()
+
+
+class TestWBSSyncServiceUpdateEpic:
+    """Tests for _update_epic method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a WBSSyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_wbs_repo = AsyncMock()
+
+        return WBSSyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            wbs_repo=mock_wbs_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_no_mapping(self, service):
+        """Should return None when mapping is None."""
+        integration = MagicMock()
+        wbs = MagicMock()
+
+        result = await service._update_epic(integration, wbs, None)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_updates_epic_in_jira(self, service):
+        """Should call jira_client.update_issue."""
+        integration = MagicMock()
+        integration.id = uuid4()
+        integration.project_key = "PROJ"
+        integration.epic_custom_field = "customfield_10011"
+
+        wbs = MagicMock()
+        wbs.id = uuid4()
+        wbs.wbs_code = "1.1"
+        wbs.name = "Updated Design Phase"
+        wbs.path = "1.1"
+        wbs.level = 2
+        wbs.description = "New description"
+        wbs.is_control_account = False
+        wbs.budget_at_completion = Decimal("0.00")
+
+        mapping = MagicMock()
+        mapping.id = uuid4()
+        mapping.jira_issue_key = "PROJ-10"
+        mapping.last_synced_at = None
+
+        result = await service._update_epic(integration, wbs, mapping)
+
+        service.jira_client.update_issue.assert_called_once()
+        call_kwargs = service.jira_client.update_issue.call_args[1]
+        assert call_kwargs["issue_key"] == "PROJ-10"
+        assert call_kwargs["summary"] == "Updated Design Phase"
+
+    @pytest.mark.asyncio
+    async def test_updates_mapping_timestamp(self, service):
+        """Should update mapping's last_synced_at."""
+        integration = MagicMock()
+        integration.id = uuid4()
+        integration.project_key = "PROJ"
+        integration.epic_custom_field = None
+
+        wbs = MagicMock()
+        wbs.id = uuid4()
+        wbs.wbs_code = "1.1"
+        wbs.name = "Design Phase"
+        wbs.path = "1.1"
+        wbs.level = 2
+        wbs.description = None
+        wbs.is_control_account = False
+        wbs.budget_at_completion = Decimal("0.00")
+
+        mapping = MagicMock()
+        mapping.id = uuid4()
+        mapping.jira_issue_key = "PROJ-10"
+
+        result = await service._update_epic(integration, wbs, mapping)
+
+        service.mapping_repo.update.assert_called_once()
+        assert result is mapping
+
+
+class TestWBSSyncServiceSyncWBSToJira:
+    """Tests for sync_wbs_to_jira method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a WBSSyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_wbs_repo = AsyncMock()
+
+        return WBSSyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            wbs_repo=mock_wbs_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_for_missing_integration(self, service):
+        """Should raise IntegrationNotFoundError."""
+        integration_id = uuid4()
+        service.integration_repo.get_by_id.return_value = None
+
+        with pytest.raises(IntegrationNotFoundError):
+            await service.sync_wbs_to_jira(integration_id)
+
+    @pytest.mark.asyncio
+    async def test_raises_for_disabled_sync(self, service):
+        """Should raise SyncDisabledError."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.sync_enabled = False
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        with pytest.raises(SyncDisabledError):
+            await service.sync_wbs_to_jira(integration_id)
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_result_for_no_elements(self, service):
+        """Should return empty result when no WBS elements."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        service.integration_repo.get_by_id.return_value = mock_integration
+        service.wbs_repo.get_by_program.return_value = []
+
+        result = await service.sync_wbs_to_jira(integration_id)
+
+        assert result.success is True
+        assert result.items_synced == 0
+        assert result.items_failed == 0
+
+    @pytest.mark.asyncio
+    async def test_creates_epics_for_unmapped_wbs(self, service):
+        """Should create Epics for unmapped WBS elements."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        mock_integration.project_key = "PROJ"
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        wbs = MagicMock()
+        wbs.id = uuid4()
+        wbs.wbs_code = "1.1"
+        wbs.name = "Design"
+        wbs.level = 2
+        wbs.path = "1.1"
+        wbs.description = None
+        wbs.is_control_account = False
+        wbs.budget_at_completion = Decimal("0.00")
+        service.wbs_repo.get_by_program.return_value = [wbs]
+        service.mapping_repo.get_by_wbs.return_value = None
+
+        now = datetime.now(UTC)
+        epic_data = JiraEpicData(
+            key="PROJ-10",
+            id="10010",
+            name="1.1 - Design",
+            summary="Design",
+            description=None,
+            status="To Do",
+            created=now,
+            updated=now,
+        )
+        service.jira_client.create_epic.return_value = epic_data
+
+        mock_mapping = MagicMock()
+        mock_mapping.id = uuid4()
+        service.mapping_repo.create.return_value = mock_mapping
+
+        result = await service.sync_wbs_to_jira(integration_id)
+
+        assert result.success is True
+        assert result.items_synced == 1
+        assert len(result.created_mappings) == 1
+
+    @pytest.mark.asyncio
+    async def test_logs_sync_operation(self, service):
+        """Should create sync log entry when there's something to sync."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        mock_integration.project_key = "PROJ"
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        # Add a WBS element so sync actually happens
+        wbs = MagicMock()
+        wbs.id = uuid4()
+        wbs.wbs_code = "1.1"
+        wbs.name = "Design"
+        wbs.level = 2
+        wbs.path = "1.1"
+        wbs.description = None
+        wbs.is_control_account = False
+        wbs.budget_at_completion = Decimal("0.00")
+        service.wbs_repo.get_by_program.return_value = [wbs]
+        service.mapping_repo.get_by_wbs.return_value = None
+
+        now = datetime.now(UTC)
+        epic_data = JiraEpicData(
+            key="PROJ-10",
+            id="10010",
+            name="1.1 - Design",
+            summary="Design",
+            description=None,
+            status="To Do",
+            created=now,
+            updated=now,
+        )
+        service.jira_client.create_epic.return_value = epic_data
+
+        mock_mapping = MagicMock()
+        mock_mapping.id = uuid4()
+        service.mapping_repo.create.return_value = mock_mapping
+
+        await service.sync_wbs_to_jira(integration_id)
+
+        service.sync_log_repo.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handles_partial_failure(self, service):
+        """Should report partial success on some failures."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        mock_integration.project_key = "PROJ"
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        # Create two WBS elements
+        wbs1 = MagicMock()
+        wbs1.id = uuid4()
+        wbs1.wbs_code = "1.1"
+        wbs1.name = "Design"
+        wbs1.level = 2
+        wbs1.path = "1.1"
+        wbs1.description = None
+        wbs1.is_control_account = False
+        wbs1.budget_at_completion = Decimal("0.00")
+
+        wbs2 = MagicMock()
+        wbs2.id = uuid4()
+        wbs2.wbs_code = "1.2"
+        wbs2.name = "Build"
+        wbs2.level = 2
+        wbs2.path = "1.2"
+        wbs2.description = None
+        wbs2.is_control_account = False
+        wbs2.budget_at_completion = Decimal("0.00")
+
+        service.wbs_repo.get_by_program.return_value = [wbs1, wbs2]
+        service.mapping_repo.get_by_wbs.return_value = None
+
+        # First succeeds, second fails
+        now = datetime.now(UTC)
+        epic_data = JiraEpicData(
+            key="PROJ-10",
+            id="10010",
+            name="1.1 - Design",
+            summary="Design",
+            description=None,
+            status="To Do",
+            created=now,
+            updated=now,
+        )
+        service.jira_client.create_epic.side_effect = [
+            epic_data,
+            JiraSyncError("Jira API error"),
+        ]
+
+        mock_mapping = MagicMock()
+        mock_mapping.id = uuid4()
+        service.mapping_repo.create.return_value = mock_mapping
+
+        result = await service.sync_wbs_to_jira(integration_id)
+
+        assert result.success is True  # Partial success
+        assert result.items_synced == 1
+        assert result.items_failed == 1
+        assert len(result.errors) == 1
+
+
+class TestWBSSyncServicePullFromJira:
+    """Tests for pull_from_jira method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a WBSSyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_wbs_repo = AsyncMock()
+
+        return WBSSyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            wbs_repo=mock_wbs_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_for_missing_integration(self, service):
+        """Should raise IntegrationNotFoundError."""
+        integration_id = uuid4()
+        service.integration_repo.get_by_id.return_value = None
+
+        with pytest.raises(IntegrationNotFoundError):
+            await service.pull_from_jira(integration_id)
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_no_mappings(self, service):
+        """Should return empty result when no pullable mappings."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        service.integration_repo.get_by_id.return_value = mock_integration
+        service.mapping_repo.get_by_integration.return_value = []
+
+        result = await service.pull_from_jira(integration_id)
+
+        assert result.success is True
+        assert result.items_synced == 0
+
+    @pytest.mark.asyncio
+    async def test_filters_pullable_mappings(self, service):
+        """Should only pull from bidirectional or from_jira mappings."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        # Create mapping with to_jira direction (should be skipped)
+        mapping = MagicMock()
+        mapping.id = uuid4()
+        mapping.sync_direction = "to_jira"
+        service.mapping_repo.get_by_integration.return_value = [mapping]
+
+        result = await service.pull_from_jira(integration_id)
+
+        # No pullable mappings
+        assert result.items_synced == 0
+
+    @pytest.mark.asyncio
+    async def test_updates_wbs_from_epic(self, service):
+        """Should update WBS when Jira has newer changes."""
+        integration_id = uuid4()
+        wbs_id = uuid4()
+
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        mapping = MagicMock()
+        mapping.id = uuid4()
+        mapping.wbs_id = wbs_id
+        mapping.jira_issue_key = "PROJ-10"
+        mapping.sync_direction = "bidirectional"
+        mapping.last_jira_updated = datetime(2026, 1, 1, tzinfo=UTC)
+        service.mapping_repo.get_by_integration.return_value = [mapping]
+
+        wbs = MagicMock()
+        wbs.id = wbs_id
+        wbs.wbs_code = "1.1"
+        service.wbs_repo.get_by_id.return_value = wbs
+
+        # Jira has newer update
+        epic_data = JiraIssueData(
+            key="PROJ-10",
+            id="10010",
+            summary="Updated Epic Name",
+            description="New description",
+            issue_type="Epic",
+            status="In Progress",
+            assignee=None,
+            created=datetime(2026, 1, 1, tzinfo=UTC),
+            updated=datetime(2026, 1, 18, tzinfo=UTC),  # Newer
+        )
+        service.jira_client.get_issue.return_value = epic_data
+
+        result = await service.pull_from_jira(integration_id)
+
+        assert result.items_synced == 1
+        service.wbs_repo.update.assert_called_once()
+
+
+class TestWBSSyncServiceLogSync:
+    """Tests for _log_sync method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a WBSSyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_wbs_repo = AsyncMock()
+
+        return WBSSyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            wbs_repo=mock_wbs_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_creates_sync_log_entry(self, service):
+        """Should create sync log with all parameters."""
+        integration_id = uuid4()
+        mapping_id = uuid4()
+
+        await service._log_sync(
+            integration_id=integration_id,
+            sync_type="push",
+            status="success",
+            items_synced=5,
+            error_message=None,
+            duration_ms=1500,
+            mapping_id=mapping_id,
+        )
+
+        service.sync_log_repo.create.assert_called_once()
+
+
+class TestWBSSyncServiceUpdateIntegrationSyncTime:
+    """Tests for _update_integration_sync_time method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create a WBSSyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_wbs_repo = AsyncMock()
+
+        return WBSSyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            wbs_repo=mock_wbs_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_updates_last_sync_at(self, service):
+        """Should update integration's last_sync_at."""
+        integration = MagicMock()
+        integration.id = uuid4()
+
+        await service._update_integration_sync_time(integration)
+
+        service.integration_repo.update.assert_called_once()
+        call_args = service.integration_repo.update.call_args
+        assert call_args[0][0] is integration  # First arg is the model
+        assert "last_sync_at" in call_args[0][1]  # Second arg is the update data


### PR DESCRIPTION
## Summary

- Add bidirectional sync service for WBS elements to Jira Epics
- Implement three new repository classes for Jira integration data access
- Create WBSSyncService with push/pull operations
- Add 42 unit tests for comprehensive coverage

## Changes

### New Files
- `api/src/repositories/jira_integration.py` - Repository for JiraIntegration CRUD
- `api/src/repositories/jira_mapping.py` - Repository for WBS/Activity to Jira mappings
- `api/src/repositories/jira_sync_log.py` - Repository for sync audit logs
- `api/src/services/jira_wbs_sync.py` - WBS sync service with bidirectional support
- `api/tests/unit/test_wbs_sync_service.py` - Comprehensive unit tests (42 tests)

### Features
- Push WBS elements (levels 1-2) to Jira as Epics
- Pull Epic updates from Jira to WBS elements
- Last-write-wins conflict resolution based on timestamps
- Comprehensive audit logging for all sync operations
- Support for sync direction configuration (to_jira, from_jira, bidirectional)

## Test plan

- [x] All 42 new unit tests pass
- [x] Full test suite passes (1712 tests)
- [x] ruff check passes
- [x] mypy type checking passes
- [ ] Integration testing with actual Jira instance (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)