### PR TITLE
Feature: Activity to Jira Issue Sync

### DIFF
--- a/api/src/api/v1/endpoints/jira_integration.py
+++ b/api/src/api/v1/endpoints/jira_integration.py
@@ -1,0 +1,652 @@
+"""Jira integration API endpoints.
+
+Provides endpoints for:
+- Connecting programs to Jira projects
+- Syncing WBS elements to Epics
+- Syncing Activities to Issues
+- Managing mappings
+- Viewing sync logs
+"""
+
+from typing import Annotated
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query
+
+from src.core.deps import DbSession
+from src.core.encryption import decrypt_token, encrypt_token
+from src.core.exceptions import NotFoundError
+from src.repositories.activity import ActivityRepository
+from src.repositories.jira_integration import JiraIntegrationRepository
+from src.repositories.jira_mapping import JiraMappingRepository
+from src.repositories.jira_sync_log import JiraSyncLogRepository
+from src.repositories.program import ProgramRepository
+from src.repositories.wbs import WBSElementRepository
+from src.schemas.jira_integration import (
+    ActivityProgressSyncRequest,
+    ActivityProgressSyncResponse,
+    ActivityProgressSyncResult,
+    EntityType,
+    JiraConnectionTestResponse,
+    JiraIntegrationCreate,
+    JiraIntegrationResponse,
+    JiraIntegrationUpdate,
+    JiraMappingCreate,
+    JiraMappingResponse,
+    JiraSyncLogListResponse,
+    JiraSyncLogResponse,
+    JiraSyncRequest,
+    JiraSyncResponse,
+)
+from src.services.jira_activity_sync import (
+    ActivitySyncService,
+)
+from src.services.jira_activity_sync import (
+    IntegrationNotFoundError as ActivityIntegrationNotFound,
+)
+from src.services.jira_activity_sync import (
+    SyncDisabledError as ActivitySyncDisabled,
+)
+from src.services.jira_client import JiraClient
+from src.services.jira_wbs_sync import (
+    IntegrationNotFoundError as WBSIntegrationNotFound,
+)
+from src.services.jira_wbs_sync import (
+    SyncDisabledError as WBSSyncDisabled,
+)
+from src.services.jira_wbs_sync import (
+    WBSSyncService,
+)
+
+router = APIRouter()
+
+
+# Integration endpoints
+
+
+@router.post(
+    "/integrations",
+    response_model=JiraIntegrationResponse,
+    status_code=201,
+)
+async def create_integration(
+    integration_in: JiraIntegrationCreate,
+    db: DbSession,
+) -> JiraIntegrationResponse:
+    """Create a new Jira integration for a program."""
+    # Verify program exists
+    program_repo = ProgramRepository(db)
+    program = await program_repo.get_by_id(integration_in.program_id)
+    if not program:
+        raise NotFoundError(
+            f"Program {integration_in.program_id} not found",
+            "PROGRAM_NOT_FOUND",
+        )
+
+    # Check if integration already exists
+    integration_repo = JiraIntegrationRepository(db)
+    existing = await integration_repo.get_by_program(integration_in.program_id)
+    if existing:
+        raise HTTPException(
+            status_code=409,
+            detail="Jira integration already exists for this program",
+        )
+
+    # Encrypt API token (stored as bytes in LargeBinary column)
+    encrypted_token = encrypt_token(integration_in.api_token).encode()
+
+    # Create integration
+    integration_data = {
+        "program_id": integration_in.program_id,
+        "jira_url": str(integration_in.jira_url),
+        "project_key": integration_in.project_key,
+        "email": integration_in.email,
+        "api_token_encrypted": encrypted_token,
+        "epic_custom_field": integration_in.epic_custom_field,
+    }
+
+    integration = await integration_repo.create(integration_data)
+    await db.commit()
+
+    return JiraIntegrationResponse.model_validate(integration)
+
+
+@router.get(
+    "/integrations/{integration_id}",
+    response_model=JiraIntegrationResponse,
+)
+async def get_integration(
+    integration_id: UUID,
+    db: DbSession,
+) -> JiraIntegrationResponse:
+    """Get a Jira integration by ID."""
+    integration_repo = JiraIntegrationRepository(db)
+    integration = await integration_repo.get_by_id(integration_id)
+
+    if not integration:
+        raise NotFoundError(
+            f"Jira integration {integration_id} not found",
+            "JIRA_INTEGRATION_NOT_FOUND",
+        )
+
+    return JiraIntegrationResponse.model_validate(integration)
+
+
+@router.get(
+    "/programs/{program_id}/integration",
+    response_model=JiraIntegrationResponse,
+)
+async def get_program_integration(
+    program_id: UUID,
+    db: DbSession,
+) -> JiraIntegrationResponse:
+    """Get Jira integration for a program."""
+    integration_repo = JiraIntegrationRepository(db)
+    integration = await integration_repo.get_by_program(program_id)
+
+    if not integration:
+        raise NotFoundError(
+            f"No Jira integration found for program {program_id}",
+            "JIRA_INTEGRATION_NOT_FOUND",
+        )
+
+    return JiraIntegrationResponse.model_validate(integration)
+
+
+@router.patch(
+    "/integrations/{integration_id}",
+    response_model=JiraIntegrationResponse,
+)
+async def update_integration(
+    integration_id: UUID,
+    integration_in: JiraIntegrationUpdate,
+    db: DbSession,
+) -> JiraIntegrationResponse:
+    """Update Jira integration settings."""
+    integration_repo = JiraIntegrationRepository(db)
+    integration = await integration_repo.get_by_id(integration_id)
+
+    if not integration:
+        raise NotFoundError(
+            f"Jira integration {integration_id} not found",
+            "JIRA_INTEGRATION_NOT_FOUND",
+        )
+
+    update_data = integration_in.model_dump(exclude_unset=True)
+    updated = await integration_repo.update(integration, update_data)
+    await db.commit()
+
+    return JiraIntegrationResponse.model_validate(updated)
+
+
+@router.delete(
+    "/integrations/{integration_id}",
+    status_code=204,
+)
+async def delete_integration(
+    integration_id: UUID,
+    db: DbSession,
+) -> None:
+    """Delete a Jira integration and all its mappings."""
+    integration_repo = JiraIntegrationRepository(db)
+    integration = await integration_repo.get_by_id(integration_id)
+
+    if not integration:
+        raise NotFoundError(
+            f"Jira integration {integration_id} not found",
+            "JIRA_INTEGRATION_NOT_FOUND",
+        )
+
+    await integration_repo.delete(integration.id)
+    await db.commit()
+
+
+@router.post(
+    "/integrations/{integration_id}/test",
+    response_model=JiraConnectionTestResponse,
+)
+async def test_connection(
+    integration_id: UUID,
+    db: DbSession,
+) -> JiraConnectionTestResponse:
+    """Test connection to Jira."""
+    integration_repo = JiraIntegrationRepository(db)
+    integration = await integration_repo.get_by_id(integration_id)
+
+    if not integration:
+        raise NotFoundError(
+            f"Jira integration {integration_id} not found",
+            "JIRA_INTEGRATION_NOT_FOUND",
+        )
+
+    try:
+        # Decrypt token and test connection (token stored as bytes)
+        token = decrypt_token(integration.api_token_encrypted.decode())
+        client = JiraClient(
+            jira_url=integration.jira_url,
+            email=integration.email,
+            api_token=token,
+        )
+
+        project_info = await client.get_project(integration.project_key)
+
+        return JiraConnectionTestResponse(
+            success=True,
+            message="Connection successful",
+            project_name=project_info.name,
+            issue_types=None,  # Not available from JiraProjectData
+        )
+
+    except Exception as e:
+        return JiraConnectionTestResponse(
+            success=False,
+            message=f"Connection failed: {e!s}",
+        )
+
+
+# Sync endpoints
+
+
+@router.post(
+    "/integrations/{integration_id}/sync/wbs",
+    response_model=JiraSyncResponse,
+)
+async def sync_wbs_to_jira(
+    integration_id: UUID,
+    sync_request: JiraSyncRequest,
+    db: DbSession,
+) -> JiraSyncResponse:
+    """Sync WBS elements to Jira Epics."""
+    integration_repo = JiraIntegrationRepository(db)
+    integration = await integration_repo.get_by_id(integration_id)
+
+    if not integration:
+        raise NotFoundError(
+            f"Jira integration {integration_id} not found",
+            "JIRA_INTEGRATION_NOT_FOUND",
+        )
+
+    try:
+        # Get decrypted token and create client
+        token = decrypt_token(integration.api_token_encrypted.decode())
+        client = JiraClient(
+            jira_url=integration.jira_url,
+            email=integration.email,
+            api_token=token,
+        )
+
+        # Create sync service
+        mapping_repo = JiraMappingRepository(db)
+        sync_log_repo = JiraSyncLogRepository(db)
+        wbs_repo = WBSElementRepository(db)
+
+        service = WBSSyncService(
+            jira_client=client,
+            integration_repo=integration_repo,
+            mapping_repo=mapping_repo,
+            sync_log_repo=sync_log_repo,
+            wbs_repo=wbs_repo,
+        )
+
+        # Run sync
+        result = await service.sync_wbs_to_jira(
+            integration_id=integration_id,
+            wbs_ids=sync_request.entity_ids,
+        )
+
+        await db.commit()
+
+        return JiraSyncResponse(
+            success=result.success,
+            sync_type="push",
+            items_synced=result.items_synced,
+            items_failed=result.items_failed,
+            duration_ms=result.duration_ms,
+            errors=result.errors,
+        )
+
+    except (WBSIntegrationNotFound, WBSSyncDisabled) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.post(
+    "/integrations/{integration_id}/sync/activities",
+    response_model=JiraSyncResponse,
+)
+async def sync_activities_to_jira(
+    integration_id: UUID,
+    sync_request: JiraSyncRequest,
+    db: DbSession,
+) -> JiraSyncResponse:
+    """Sync Activities to Jira Issues."""
+    integration_repo = JiraIntegrationRepository(db)
+    integration = await integration_repo.get_by_id(integration_id)
+
+    if not integration:
+        raise NotFoundError(
+            f"Jira integration {integration_id} not found",
+            "JIRA_INTEGRATION_NOT_FOUND",
+        )
+
+    try:
+        # Get decrypted token and create client
+        token = decrypt_token(integration.api_token_encrypted.decode())
+        client = JiraClient(
+            jira_url=integration.jira_url,
+            email=integration.email,
+            api_token=token,
+        )
+
+        # Create sync service
+        mapping_repo = JiraMappingRepository(db)
+        sync_log_repo = JiraSyncLogRepository(db)
+        activity_repo = ActivityRepository(db)
+
+        service = ActivitySyncService(
+            jira_client=client,
+            integration_repo=integration_repo,
+            mapping_repo=mapping_repo,
+            sync_log_repo=sync_log_repo,
+            activity_repo=activity_repo,
+        )
+
+        # Run sync
+        result = await service.sync_activities_to_jira(
+            integration_id=integration_id,
+            activity_ids=sync_request.entity_ids,
+        )
+
+        await db.commit()
+
+        return JiraSyncResponse(
+            success=result.success,
+            sync_type="push",
+            items_synced=result.items_synced,
+            items_failed=result.items_failed,
+            duration_ms=result.duration_ms,
+            errors=result.errors,
+        )
+
+    except (ActivityIntegrationNotFound, ActivitySyncDisabled) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.post(
+    "/integrations/{integration_id}/sync/progress",
+    response_model=ActivityProgressSyncResponse,
+)
+async def sync_activity_progress(
+    integration_id: UUID,
+    request: ActivityProgressSyncRequest,
+    db: DbSession,
+) -> ActivityProgressSyncResponse:
+    """Sync activity progress to Jira Issues."""
+    integration_repo = JiraIntegrationRepository(db)
+    integration = await integration_repo.get_by_id(integration_id)
+
+    if not integration:
+        raise NotFoundError(
+            f"Jira integration {integration_id} not found",
+            "JIRA_INTEGRATION_NOT_FOUND",
+        )
+
+    try:
+        # Get decrypted token and create client
+        token = decrypt_token(integration.api_token_encrypted.decode())
+        client = JiraClient(
+            jira_url=integration.jira_url,
+            email=integration.email,
+            api_token=token,
+        )
+
+        # Create sync service
+        mapping_repo = JiraMappingRepository(db)
+        sync_log_repo = JiraSyncLogRepository(db)
+        activity_repo = ActivityRepository(db)
+
+        service = ActivitySyncService(
+            jira_client=client,
+            integration_repo=integration_repo,
+            mapping_repo=mapping_repo,
+            sync_log_repo=sync_log_repo,
+            activity_repo=activity_repo,
+        )
+
+        # Run progress sync
+        result = await service.sync_progress(
+            integration_id=integration_id,
+            activity_ids=request.activity_ids,
+        )
+
+        await db.commit()
+
+        # Build detailed results
+        results = []
+        for mapping_id in result.updated_mappings:
+            mapping = await mapping_repo.get_by_id(mapping_id)
+            if mapping and mapping.activity_id:
+                activity = await activity_repo.get_by_id(mapping.activity_id)
+                if activity:
+                    results.append(
+                        ActivityProgressSyncResult(
+                            activity_id=activity.id,
+                            activity_code=activity.code,
+                            jira_issue_key=mapping.jira_issue_key,
+                            percent_complete=activity.percent_complete,
+                            jira_status="synced",
+                            success=True,
+                        )
+                    )
+
+        return ActivityProgressSyncResponse(
+            success=result.success,
+            synced_count=result.items_synced,
+            failed_count=result.items_failed,
+            results=results,
+        )
+
+    except (ActivityIntegrationNotFound, ActivitySyncDisabled) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+@router.post(
+    "/integrations/{integration_id}/sync/pull",
+    response_model=JiraSyncResponse,
+)
+async def pull_from_jira(
+    integration_id: UUID,
+    sync_request: JiraSyncRequest,
+    db: DbSession,
+) -> JiraSyncResponse:
+    """Pull updates from Jira to Activities."""
+    integration_repo = JiraIntegrationRepository(db)
+    integration = await integration_repo.get_by_id(integration_id)
+
+    if not integration:
+        raise NotFoundError(
+            f"Jira integration {integration_id} not found",
+            "JIRA_INTEGRATION_NOT_FOUND",
+        )
+
+    try:
+        # Get decrypted token and create client
+        token = decrypt_token(integration.api_token_encrypted.decode())
+        client = JiraClient(
+            jira_url=integration.jira_url,
+            email=integration.email,
+            api_token=token,
+        )
+
+        # Create sync service
+        mapping_repo = JiraMappingRepository(db)
+        sync_log_repo = JiraSyncLogRepository(db)
+        activity_repo = ActivityRepository(db)
+
+        service = ActivitySyncService(
+            jira_client=client,
+            integration_repo=integration_repo,
+            mapping_repo=mapping_repo,
+            sync_log_repo=sync_log_repo,
+            activity_repo=activity_repo,
+        )
+
+        # Run pull
+        result = await service.pull_from_jira(
+            integration_id=integration_id,
+            mapping_ids=sync_request.entity_ids,
+        )
+
+        await db.commit()
+
+        return JiraSyncResponse(
+            success=result.success,
+            sync_type="pull",
+            items_synced=result.items_synced,
+            items_failed=result.items_failed,
+            duration_ms=result.duration_ms,
+            errors=result.errors,
+        )
+
+    except (ActivityIntegrationNotFound, ActivitySyncDisabled) as e:
+        raise HTTPException(status_code=400, detail=str(e)) from e
+
+
+# Mapping endpoints
+
+
+@router.get(
+    "/integrations/{integration_id}/mappings",
+    response_model=list[JiraMappingResponse],
+)
+async def list_mappings(
+    integration_id: UUID,
+    db: DbSession,
+    entity_type: Annotated[
+        EntityType | None,
+        Query(description="Filter by entity type"),
+    ] = None,
+) -> list[JiraMappingResponse]:
+    """List all mappings for an integration."""
+    mapping_repo = JiraMappingRepository(db)
+    mappings = await mapping_repo.get_by_integration(
+        integration_id,
+        entity_type=entity_type.value if entity_type else None,
+    )
+
+    return [JiraMappingResponse.model_validate(m) for m in mappings]
+
+
+@router.post(
+    "/integrations/{integration_id}/mappings",
+    response_model=JiraMappingResponse,
+    status_code=201,
+)
+async def create_mapping(
+    integration_id: UUID,
+    mapping_in: JiraMappingCreate,
+    db: DbSession,
+) -> JiraMappingResponse:
+    """Create a manual mapping between an entity and a Jira Issue."""
+    integration_repo = JiraIntegrationRepository(db)
+    integration = await integration_repo.get_by_id(integration_id)
+
+    if not integration:
+        raise NotFoundError(
+            f"Jira integration {integration_id} not found",
+            "JIRA_INTEGRATION_NOT_FOUND",
+        )
+
+    # Validate entity exists
+    if mapping_in.entity_type == EntityType.WBS and mapping_in.wbs_id:
+        wbs_repo = WBSElementRepository(db)
+        wbs = await wbs_repo.get_by_id(mapping_in.wbs_id)
+        if not wbs:
+            raise NotFoundError(
+                f"WBS element {mapping_in.wbs_id} not found",
+                "WBS_NOT_FOUND",
+            )
+    elif mapping_in.entity_type == EntityType.ACTIVITY and mapping_in.activity_id:
+        activity_repo = ActivityRepository(db)
+        activity = await activity_repo.get_by_id(mapping_in.activity_id)
+        if not activity:
+            raise NotFoundError(
+                f"Activity {mapping_in.activity_id} not found",
+                "ACTIVITY_NOT_FOUND",
+            )
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail="Entity ID (wbs_id or activity_id) required based on entity_type",
+        )
+
+    mapping_repo = JiraMappingRepository(db)
+    mapping_data = {
+        "integration_id": integration_id,
+        "entity_type": mapping_in.entity_type.value,
+        "wbs_id": mapping_in.wbs_id,
+        "activity_id": mapping_in.activity_id,
+        "jira_issue_key": mapping_in.jira_issue_key,
+        "sync_direction": mapping_in.sync_direction.value,
+    }
+
+    mapping = await mapping_repo.create(mapping_data)
+    await db.commit()
+
+    return JiraMappingResponse.model_validate(mapping)
+
+
+@router.delete(
+    "/mappings/{mapping_id}",
+    status_code=204,
+)
+async def delete_mapping(
+    mapping_id: UUID,
+    db: DbSession,
+) -> None:
+    """Delete a mapping."""
+    mapping_repo = JiraMappingRepository(db)
+    mapping = await mapping_repo.get_by_id(mapping_id)
+
+    if not mapping:
+        raise NotFoundError(
+            f"Mapping {mapping_id} not found",
+            "MAPPING_NOT_FOUND",
+        )
+
+    await mapping_repo.delete(mapping.id)
+    await db.commit()
+
+
+# Sync log endpoints
+
+
+@router.get(
+    "/integrations/{integration_id}/logs",
+    response_model=JiraSyncLogListResponse,
+)
+async def list_sync_logs(
+    integration_id: UUID,
+    db: DbSession,
+    page: Annotated[int, Query(ge=1)] = 1,
+    per_page: Annotated[int, Query(ge=1, le=100)] = 20,
+) -> JiraSyncLogListResponse:
+    """List sync logs for an integration."""
+    sync_log_repo = JiraSyncLogRepository(db)
+    # Get logs with high limit to enable pagination
+    all_logs = await sync_log_repo.get_by_integration(
+        integration_id,
+        limit=1000,
+    )
+
+    # Manual pagination
+    total = len(all_logs)
+    start_idx = (page - 1) * per_page
+    end_idx = start_idx + per_page
+    paginated_logs = all_logs[start_idx:end_idx]
+
+    return JiraSyncLogListResponse(
+        items=[JiraSyncLogResponse.model_validate(log) for log in paginated_logs],
+        total=total,
+        page=page,
+        per_page=per_page,
+    )

--- a/api/src/api/v1/router.py
+++ b/api/src/api/v1/router.py
@@ -9,6 +9,7 @@ from src.api.v1.endpoints import (
     dependencies,
     evms,
     import_export,
+    jira_integration,
     management_reserve,
     programs,
     reports,
@@ -104,4 +105,10 @@ api_router.include_router(
     management_reserve.router,
     prefix="/mr",
     tags=["Management Reserve"],
+)
+
+api_router.include_router(
+    jira_integration.router,
+    prefix="/jira",
+    tags=["Jira Integration"],
 )

--- a/api/src/schemas/__init__.py
+++ b/api/src/schemas/__init__.py
@@ -91,6 +91,32 @@ from src.schemas.wbs import (
     WBSWithChildrenResponse,
 )
 
+# Jira integration schemas
+from src.schemas.jira_integration import (
+    ActivityProgressSyncRequest,
+    ActivityProgressSyncResponse,
+    ActivityProgressSyncResult,
+    EntityType,
+    JiraConnectionTestResponse,
+    JiraIntegrationCreate,
+    JiraIntegrationResponse,
+    JiraIntegrationUpdate,
+    JiraMappingBrief,
+    JiraMappingCreate,
+    JiraMappingResponse,
+    JiraStatusMapping,
+    JiraStatusMappingConfig,
+    JiraSyncLogListResponse,
+    JiraSyncLogResponse,
+    JiraSyncRequest,
+    JiraSyncResponse,
+    JiraWebhookPayload,
+    SyncDirection,
+    SyncResultItem,
+    SyncStatus,
+    SyncType,
+)
+
 __all__ = [
     "ActivityBriefResponse",
     # Activity
@@ -149,4 +175,27 @@ __all__ = [
     "WBSTreeResponse",
     "WBSUpdate",
     "WBSWithChildrenResponse",
+    # Jira Integration
+    "ActivityProgressSyncRequest",
+    "ActivityProgressSyncResponse",
+    "ActivityProgressSyncResult",
+    "EntityType",
+    "JiraConnectionTestResponse",
+    "JiraIntegrationCreate",
+    "JiraIntegrationResponse",
+    "JiraIntegrationUpdate",
+    "JiraMappingBrief",
+    "JiraMappingCreate",
+    "JiraMappingResponse",
+    "JiraStatusMapping",
+    "JiraStatusMappingConfig",
+    "JiraSyncLogListResponse",
+    "JiraSyncLogResponse",
+    "JiraSyncRequest",
+    "JiraSyncResponse",
+    "JiraWebhookPayload",
+    "SyncDirection",
+    "SyncResultItem",
+    "SyncStatus",
+    "SyncType",
 ]

--- a/api/src/schemas/jira_integration.py
+++ b/api/src/schemas/jira_integration.py
@@ -1,0 +1,291 @@
+"""Pydantic schemas for Jira integration API."""
+
+from datetime import datetime
+from decimal import Decimal
+from enum import Enum
+from typing import Any
+from uuid import UUID
+
+from pydantic import BaseModel, ConfigDict, Field, HttpUrl
+
+
+class SyncDirection(str, Enum):
+    """Sync direction for mappings."""
+
+    TO_JIRA = "to_jira"
+    FROM_JIRA = "from_jira"
+    BIDIRECTIONAL = "bidirectional"
+
+
+class EntityType(str, Enum):
+    """Type of mapped entity."""
+
+    WBS = "wbs"
+    ACTIVITY = "activity"
+
+
+class SyncType(str, Enum):
+    """Type of sync operation."""
+
+    PUSH = "push"
+    PULL = "pull"
+    WEBHOOK = "webhook"
+    FULL = "full"
+
+
+class SyncStatus(str, Enum):
+    """Status of sync operation."""
+
+    SUCCESS = "success"
+    FAILED = "failed"
+    PARTIAL = "partial"
+
+
+# Integration schemas
+
+
+class JiraIntegrationCreate(BaseModel):
+    """Schema for creating a Jira integration connection."""
+
+    program_id: UUID = Field(..., description="Program ID to connect")
+    jira_url: HttpUrl = Field(
+        ..., description="Jira Cloud URL (e.g., https://company.atlassian.net)"
+    )
+    project_key: str = Field(
+        ..., min_length=1, max_length=20, description="Target Jira project key"
+    )
+    email: str = Field(..., description="User email for Jira authentication")
+    api_token: str = Field(..., description="Jira API token (will be encrypted)")
+    epic_custom_field: str | None = Field(default=None, description="Custom field ID for Epic Name")
+
+
+class JiraIntegrationUpdate(BaseModel):
+    """Schema for updating Jira integration settings."""
+
+    sync_enabled: bool | None = Field(default=None, description="Enable/disable sync")
+    epic_custom_field: str | None = Field(default=None, description="Custom field ID for Epic Name")
+
+
+class JiraIntegrationResponse(BaseModel):
+    """Response schema for Jira integration."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    program_id: UUID
+    jira_url: str
+    project_key: str
+    email: str
+    sync_enabled: bool
+    sync_status: str
+    last_sync_at: datetime | None
+    epic_custom_field: str | None
+    created_at: datetime
+    updated_at: datetime | None
+
+
+# Mapping schemas
+
+
+class JiraMappingCreate(BaseModel):
+    """Schema for creating a manual mapping."""
+
+    entity_type: EntityType = Field(..., description="Type of entity to map")
+    wbs_id: UUID | None = Field(default=None, description="WBS element ID (if type is wbs)")
+    activity_id: UUID | None = Field(default=None, description="Activity ID (if type is activity)")
+    jira_issue_key: str = Field(..., description="Jira issue key (e.g., PROJ-123)")
+    sync_direction: SyncDirection = Field(
+        default=SyncDirection.BIDIRECTIONAL, description="Sync direction"
+    )
+
+
+class JiraMappingResponse(BaseModel):
+    """Response schema for Jira mapping."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    integration_id: UUID
+    entity_type: str
+    wbs_id: UUID | None
+    activity_id: UUID | None
+    jira_issue_key: str
+    jira_issue_id: str | None
+    sync_direction: str
+    last_synced_at: datetime | None
+    last_jira_updated: datetime | None
+    created_at: datetime
+
+
+class JiraMappingBrief(BaseModel):
+    """Brief mapping info for list responses."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    entity_type: str
+    jira_issue_key: str
+    last_synced_at: datetime | None
+
+
+# Sync request/response schemas
+
+
+class JiraSyncRequest(BaseModel):
+    """Request schema for triggering a sync operation."""
+
+    entity_type: EntityType | None = Field(
+        default=None, description="Limit sync to entity type (wbs or activity)"
+    )
+    entity_ids: list[UUID] | None = Field(
+        default=None, description="Specific entity IDs to sync (if not provided, syncs all)"
+    )
+    sync_direction: SyncDirection = Field(
+        default=SyncDirection.TO_JIRA, description="Direction of sync"
+    )
+    include_progress: bool = Field(
+        default=True, description="Include progress/status sync for activities"
+    )
+
+
+class SyncResultItem(BaseModel):
+    """Individual item sync result."""
+
+    entity_id: UUID
+    entity_type: str
+    jira_issue_key: str | None
+    success: bool
+    error_message: str | None = None
+
+
+class JiraSyncResponse(BaseModel):
+    """Response schema for sync operation."""
+
+    success: bool
+    sync_type: str
+    items_synced: int
+    items_failed: int
+    duration_ms: int
+    errors: list[str] = Field(default_factory=list)
+    results: list[SyncResultItem] = Field(default_factory=list)
+
+
+# Sync log schemas
+
+
+class JiraSyncLogResponse(BaseModel):
+    """Response schema for sync log entry."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    integration_id: UUID
+    mapping_id: UUID | None
+    sync_type: str
+    status: str
+    items_synced: int
+    error_message: str | None
+    duration_ms: int | None
+    created_at: datetime
+
+
+class JiraSyncLogListResponse(BaseModel):
+    """Paginated list of sync logs."""
+
+    items: list[JiraSyncLogResponse]
+    total: int
+    page: int
+    per_page: int
+
+
+# Progress sync schemas
+
+
+class ActivityProgressSyncRequest(BaseModel):
+    """Request schema for syncing activity progress to Jira."""
+
+    activity_ids: list[UUID] | None = Field(
+        default=None, description="Specific activity IDs (if not provided, syncs all mapped)"
+    )
+
+
+class ActivityProgressSyncResult(BaseModel):
+    """Result of activity progress sync."""
+
+    activity_id: UUID
+    activity_code: str
+    jira_issue_key: str
+    percent_complete: Decimal
+    jira_status: str
+    success: bool
+    message: str | None = None
+
+
+class ActivityProgressSyncResponse(BaseModel):
+    """Response for progress sync operation."""
+
+    success: bool
+    synced_count: int
+    failed_count: int
+    results: list[ActivityProgressSyncResult]
+
+
+# Status mapping schemas
+
+
+class JiraStatusMapping(BaseModel):
+    """Mapping between percent complete and Jira status."""
+
+    min_percent: Decimal = Field(..., ge=0, le=100)
+    max_percent: Decimal = Field(..., ge=0, le=100)
+    jira_status: str
+    jira_transition_id: str | None = None
+
+
+class JiraStatusMappingConfig(BaseModel):
+    """Configuration for Jira status mappings."""
+
+    mappings: list[JiraStatusMapping] = Field(
+        default_factory=lambda: [
+            JiraStatusMapping(
+                min_percent=Decimal("0"),
+                max_percent=Decimal("0"),
+                jira_status="To Do",
+            ),
+            JiraStatusMapping(
+                min_percent=Decimal("1"),
+                max_percent=Decimal("99"),
+                jira_status="In Progress",
+            ),
+            JiraStatusMapping(
+                min_percent=Decimal("100"),
+                max_percent=Decimal("100"),
+                jira_status="Done",
+            ),
+        ]
+    )
+
+
+# Webhook schemas
+
+
+class JiraWebhookPayload(BaseModel):
+    """Schema for Jira webhook payload."""
+
+    webhookEvent: str
+    issue: dict[str, Any] | None = None
+    changelog: dict[str, Any] | None = None
+    user: dict[str, Any] | None = None
+    timestamp: int | None = None
+
+
+# Connection test
+
+
+class JiraConnectionTestResponse(BaseModel):
+    """Response for connection test."""
+
+    success: bool
+    message: str
+    project_name: str | None = None
+    issue_types: list[str] | None = None

--- a/api/src/services/__init__.py
+++ b/api/src/services/__init__.py
@@ -2,10 +2,12 @@
 
 from src.services.cpm import CPMEngine
 from src.services.evms import EVMSCalculator
+from src.services.jira_activity_sync import ActivitySyncService
 from src.services.jira_client import JiraClient
 from src.services.jira_wbs_sync import WBSSyncService
 
 __all__ = [
+    "ActivitySyncService",
     "CPMEngine",
     "EVMSCalculator",
     "JiraClient",

--- a/api/src/services/jira_activity_sync.py
+++ b/api/src/services/jira_activity_sync.py
@@ -1,0 +1,871 @@
+"""Activity to Jira Issue synchronization service.
+
+Provides bidirectional sync between Activities and Jira Issues (Tasks/Stories).
+Supports:
+- Push Activities to Jira as Issues
+- Link to parent Epic (from WBS mapping)
+- Sync progress and status
+- Pull Issue updates from Jira
+- Comprehensive audit logging
+
+Usage:
+    service = ActivitySyncService(
+        jira_client=client,
+        integration_repo=integration_repo,
+        mapping_repo=mapping_repo,
+        sync_log_repo=sync_log_repo,
+        activity_repo=activity_repo,
+    )
+    result = await service.sync_activities_to_jira(integration_id, activity_ids)
+"""
+
+from __future__ import annotations
+
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from src.models.jira_mapping import EntityType, SyncDirection
+from src.models.jira_sync_log import SyncStatus, SyncType
+from src.services.jira_client import JiraClient, JiraSyncError
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from src.models.activity import Activity
+    from src.models.jira_integration import JiraIntegration
+    from src.models.jira_mapping import JiraMapping
+    from src.repositories.activity import ActivityRepository
+    from src.repositories.jira_integration import JiraIntegrationRepository
+    from src.repositories.jira_mapping import JiraMappingRepository
+    from src.repositories.jira_sync_log import JiraSyncLogRepository
+
+
+logger = structlog.get_logger(__name__)
+
+
+class ActivitySyncError(Exception):
+    """Base exception for Activity sync operations."""
+
+    def __init__(self, message: str, details: dict[str, Any] | None = None):
+        self.message = message
+        self.details = details or {}
+        super().__init__(message)
+
+
+class IntegrationNotFoundError(ActivitySyncError):
+    """Jira integration not found."""
+
+    pass
+
+
+class SyncDisabledError(ActivitySyncError):
+    """Sync is disabled for this integration."""
+
+    pass
+
+
+class ParentEpicNotFoundError(ActivitySyncError):
+    """Parent WBS element has no Epic mapping."""
+
+    pass
+
+
+# Jira status mappings based on percent_complete
+JIRA_STATUS_MAPPINGS = {
+    "not_started": "To Do",
+    "in_progress": "In Progress",
+    "completed": "Done",
+}
+
+
+@dataclass
+class SyncResult:
+    """Result of a sync operation."""
+
+    success: bool
+    items_synced: int
+    items_failed: int
+    errors: list[str] = field(default_factory=list)
+    created_mappings: list[UUID] = field(default_factory=list)
+    updated_mappings: list[UUID] = field(default_factory=list)
+    duration_ms: int = 0
+
+
+@dataclass
+class ActivitySyncItem:
+    """Represents an Activity to sync with its mapping status."""
+
+    activity: Activity
+    mapping: JiraMapping | None
+    parent_epic_key: str | None
+    action: str  # "create", "update", "skip"
+    jira_key: str | None = None
+    error: str | None = None
+
+
+class ActivitySyncService:
+    """
+    Service for syncing Activities to Jira Issues.
+
+    Handles:
+    - Activity → Task/Story creation
+    - Link to parent Epic (from WBS mapping)
+    - Progress and status sync
+    - Bidirectional updates
+    - Audit logging for compliance
+
+    Attributes:
+        jira_client: Jira API client
+        integration_repo: Repository for Jira integrations
+        mapping_repo: Repository for entity mappings
+        sync_log_repo: Repository for sync audit logs
+        activity_repo: Repository for activities
+    """
+
+    def __init__(
+        self,
+        jira_client: JiraClient,
+        integration_repo: JiraIntegrationRepository,
+        mapping_repo: JiraMappingRepository,
+        sync_log_repo: JiraSyncLogRepository,
+        activity_repo: ActivityRepository,
+    ) -> None:
+        """Initialize Activity sync service.
+
+        Args:
+            jira_client: Jira API client instance
+            integration_repo: Repository for Jira integrations
+            mapping_repo: Repository for entity mappings
+            sync_log_repo: Repository for sync audit logs
+            activity_repo: Repository for activities
+        """
+        self.jira_client = jira_client
+        self.integration_repo = integration_repo
+        self.mapping_repo = mapping_repo
+        self.sync_log_repo = sync_log_repo
+        self.activity_repo = activity_repo
+
+    async def sync_activities_to_jira(
+        self,
+        integration_id: UUID,
+        activity_ids: list[UUID] | None = None,
+    ) -> SyncResult:
+        """Sync Activities to Jira as Issues.
+
+        Creates new Issues for unmapped Activities and updates
+        existing mappings when Activity data has changed.
+
+        Args:
+            integration_id: Jira integration UUID
+            activity_ids: Optional list of specific Activity IDs to sync.
+                         If None, syncs all activities for the program.
+
+        Returns:
+            SyncResult with sync statistics
+
+        Raises:
+            IntegrationNotFoundError: If integration doesn't exist
+            SyncDisabledError: If sync is disabled
+            ActivitySyncError: If sync fails
+        """
+        start_time = time.time()
+        result = SyncResult(success=True, items_synced=0, items_failed=0)
+
+        try:
+            # Validate integration
+            integration = await self._get_integration(integration_id)
+
+            # Get activities to sync
+            activities = await self._get_syncable_activities(integration.program_id, activity_ids)
+
+            if not activities:
+                logger.info(
+                    "activity_sync_no_elements",
+                    integration_id=str(integration_id),
+                )
+                return result
+
+            # Prepare sync items with mapping status and parent epic
+            sync_items = await self._prepare_sync_items(integration_id, activities)
+
+            # Process each item
+            for item in sync_items:
+                try:
+                    if item.action == "create":
+                        new_mapping = await self._create_issue(integration, item)
+                        result.created_mappings.append(new_mapping.id)
+                        result.items_synced += 1
+                    elif item.action == "update":
+                        updated_mapping = await self._update_issue(
+                            integration, item.activity, item.mapping
+                        )
+                        if updated_mapping:
+                            result.updated_mappings.append(updated_mapping.id)
+                        result.items_synced += 1
+                    # Skip items are not counted
+                except JiraSyncError as e:
+                    item.error = str(e)
+                    result.errors.append(f"Activity {item.activity.code}: {e}")
+                    result.items_failed += 1
+                    logger.warning(
+                        "activity_sync_item_failed",
+                        activity_id=str(item.activity.id),
+                        activity_code=item.activity.code,
+                        error=str(e),
+                    )
+
+            # Determine overall status
+            if result.items_failed > 0 and result.items_synced > 0:
+                result.success = True  # Partial success
+                sync_status = SyncStatus.PARTIAL.value
+            elif result.items_failed > 0:
+                result.success = False
+                sync_status = SyncStatus.FAILED.value
+            else:
+                sync_status = SyncStatus.SUCCESS.value
+
+            # Calculate duration
+            result.duration_ms = int((time.time() - start_time) * 1000)
+
+            # Log sync operation
+            await self._log_sync(
+                integration_id=integration_id,
+                sync_type=SyncType.PUSH.value,
+                status=sync_status,
+                items_synced=result.items_synced,
+                error_message="; ".join(result.errors) if result.errors else None,
+                duration_ms=result.duration_ms,
+            )
+
+            # Update integration last_sync_at
+            if result.items_synced > 0:
+                await self._update_integration_sync_time(integration)
+
+            logger.info(
+                "activity_sync_completed",
+                integration_id=str(integration_id),
+                items_synced=result.items_synced,
+                items_failed=result.items_failed,
+                duration_ms=result.duration_ms,
+            )
+
+            return result
+
+        except (IntegrationNotFoundError, SyncDisabledError):
+            raise
+        except Exception as e:
+            result.success = False
+            result.errors.append(str(e))
+            result.duration_ms = int((time.time() - start_time) * 1000)
+
+            await self._log_sync(
+                integration_id=integration_id,
+                sync_type=SyncType.PUSH.value,
+                status=SyncStatus.FAILED.value,
+                items_synced=0,
+                error_message=str(e),
+                duration_ms=result.duration_ms,
+            )
+
+            logger.error(
+                "activity_sync_failed",
+                integration_id=str(integration_id),
+                error=str(e),
+            )
+            raise ActivitySyncError(f"Activity sync failed: {e}") from e
+
+    async def pull_from_jira(
+        self,
+        integration_id: UUID,
+        mapping_ids: list[UUID] | None = None,
+    ) -> SyncResult:
+        """Pull updates from Jira Issues to Activities.
+
+        Fetches Issue data from Jira and updates corresponding Activities
+        when Jira has newer changes (conflict resolution: last-write-wins).
+
+        Args:
+            integration_id: Jira integration UUID
+            mapping_ids: Optional list of specific mapping IDs to pull.
+                        If None, pulls all mapped Activities.
+
+        Returns:
+            SyncResult with sync statistics
+
+        Raises:
+            IntegrationNotFoundError: If integration doesn't exist
+            SyncDisabledError: If sync is disabled
+            ActivitySyncError: If pull fails
+        """
+        start_time = time.time()
+        result = SyncResult(success=True, items_synced=0, items_failed=0)
+
+        try:
+            integration = await self._get_integration(integration_id)
+
+            # Get mappings to pull
+            mappings = await self._get_mappings_for_pull(integration_id, mapping_ids)
+
+            if not mappings:
+                logger.info(
+                    "activity_pull_no_mappings",
+                    integration_id=str(integration_id),
+                )
+                return result
+
+            # Process each mapping
+            for mapping in mappings:
+                try:
+                    updated = await self._pull_issue_to_activity(mapping)
+                    if updated:
+                        result.updated_mappings.append(mapping.id)
+                    result.items_synced += 1
+                except JiraSyncError as e:
+                    result.errors.append(f"Issue {mapping.jira_issue_key}: {e}")
+                    result.items_failed += 1
+                    logger.warning(
+                        "activity_pull_item_failed",
+                        mapping_id=str(mapping.id),
+                        jira_key=mapping.jira_issue_key,
+                        error=str(e),
+                    )
+
+            # Determine overall status
+            if result.items_failed > 0 and result.items_synced > 0:
+                sync_status = SyncStatus.PARTIAL.value
+            elif result.items_failed > 0:
+                result.success = False
+                sync_status = SyncStatus.FAILED.value
+            else:
+                sync_status = SyncStatus.SUCCESS.value
+
+            result.duration_ms = int((time.time() - start_time) * 1000)
+
+            await self._log_sync(
+                integration_id=integration_id,
+                sync_type=SyncType.PULL.value,
+                status=sync_status,
+                items_synced=result.items_synced,
+                error_message="; ".join(result.errors) if result.errors else None,
+                duration_ms=result.duration_ms,
+            )
+
+            if result.items_synced > 0:
+                await self._update_integration_sync_time(integration)
+
+            logger.info(
+                "activity_pull_completed",
+                integration_id=str(integration_id),
+                items_synced=result.items_synced,
+                items_failed=result.items_failed,
+                duration_ms=result.duration_ms,
+            )
+
+            return result
+
+        except (IntegrationNotFoundError, SyncDisabledError):
+            raise
+        except Exception as e:
+            result.success = False
+            result.errors.append(str(e))
+            result.duration_ms = int((time.time() - start_time) * 1000)
+
+            await self._log_sync(
+                integration_id=integration_id,
+                sync_type=SyncType.PULL.value,
+                status=SyncStatus.FAILED.value,
+                items_synced=0,
+                error_message=str(e),
+                duration_ms=result.duration_ms,
+            )
+
+            logger.error(
+                "activity_pull_failed",
+                integration_id=str(integration_id),
+                error=str(e),
+            )
+            raise ActivitySyncError(f"Activity pull failed: {e}") from e
+
+    async def sync_progress(
+        self,
+        integration_id: UUID,
+        activity_ids: list[UUID] | None = None,
+    ) -> SyncResult:
+        """Sync activity progress to Jira Issues.
+
+        Updates percent_complete and triggers status transitions in Jira.
+
+        Args:
+            integration_id: Jira integration UUID
+            activity_ids: Optional list of specific Activity IDs to sync
+
+        Returns:
+            SyncResult with sync statistics
+        """
+        start_time = time.time()
+        result = SyncResult(success=True, items_synced=0, items_failed=0)
+
+        try:
+            # Validate integration exists and is enabled
+            await self._get_integration(integration_id)
+
+            # Get mapped activities
+            mappings = await self.mapping_repo.get_by_integration(
+                integration_id, entity_type=EntityType.ACTIVITY.value
+            )
+
+            if activity_ids:
+                mappings = [m for m in mappings if m.activity_id in activity_ids]
+
+            for mapping in mappings:
+                if mapping.activity_id is None:
+                    continue
+
+                try:
+                    activity = await self.activity_repo.get_by_id(mapping.activity_id)
+                    if not activity:
+                        continue
+
+                    await self._sync_activity_progress(mapping, activity)
+                    result.updated_mappings.append(mapping.id)
+                    result.items_synced += 1
+                except JiraSyncError as e:
+                    result.errors.append(f"Issue {mapping.jira_issue_key}: {e}")
+                    result.items_failed += 1
+
+            sync_status = (
+                SyncStatus.PARTIAL.value
+                if result.items_failed > 0 and result.items_synced > 0
+                else SyncStatus.SUCCESS.value
+                if result.items_failed == 0
+                else SyncStatus.FAILED.value
+            )
+
+            result.duration_ms = int((time.time() - start_time) * 1000)
+
+            await self._log_sync(
+                integration_id=integration_id,
+                sync_type=SyncType.PUSH.value,
+                status=sync_status,
+                items_synced=result.items_synced,
+                error_message="; ".join(result.errors) if result.errors else None,
+                duration_ms=result.duration_ms,
+            )
+
+            return result
+
+        except Exception as e:
+            result.success = False
+            result.errors.append(str(e))
+            result.duration_ms = int((time.time() - start_time) * 1000)
+            raise ActivitySyncError(f"Progress sync failed: {e}") from e
+
+    async def _get_integration(self, integration_id: UUID) -> JiraIntegration:
+        """Get and validate Jira integration."""
+        integration = await self.integration_repo.get_by_id(integration_id)
+        if not integration:
+            raise IntegrationNotFoundError(
+                f"Integration {integration_id} not found",
+                {"integration_id": str(integration_id)},
+            )
+
+        if not integration.sync_enabled:
+            raise SyncDisabledError(
+                f"Sync is disabled for integration {integration_id}",
+                {"integration_id": str(integration_id)},
+            )
+
+        return integration
+
+    async def _get_syncable_activities(
+        self,
+        program_id: UUID,
+        activity_ids: list[UUID] | None = None,
+    ) -> list[Activity]:
+        """Get Activities eligible for sync."""
+        all_activities = await self.activity_repo.get_by_program(program_id)
+
+        # Filter to specific IDs if provided
+        if activity_ids:
+            all_activities = [a for a in all_activities if a.id in activity_ids]
+
+        return all_activities
+
+    async def _prepare_sync_items(
+        self,
+        integration_id: UUID,
+        activities: list[Activity],
+    ) -> list[ActivitySyncItem]:
+        """Prepare sync items with mapping status and parent epic."""
+        items = []
+
+        for activity in activities:
+            mapping = await self.mapping_repo.get_by_activity(integration_id, activity.id)
+
+            # Get parent WBS Epic mapping
+            parent_epic_key = await self._get_parent_epic_key(integration_id, activity.wbs_id)
+
+            if mapping is None:
+                # New Activity - create Issue
+                items.append(
+                    ActivitySyncItem(
+                        activity=activity,
+                        mapping=None,
+                        parent_epic_key=parent_epic_key,
+                        action="create",
+                    )
+                )
+            elif mapping.sync_direction in (
+                SyncDirection.TO_JIRA.value,
+                SyncDirection.BIDIRECTIONAL.value,
+            ):
+                # Existing mapping - update Issue
+                items.append(
+                    ActivitySyncItem(
+                        activity=activity,
+                        mapping=mapping,
+                        parent_epic_key=parent_epic_key,
+                        action="update",
+                    )
+                )
+            else:
+                # From Jira only - skip push
+                items.append(
+                    ActivitySyncItem(
+                        activity=activity,
+                        mapping=mapping,
+                        parent_epic_key=parent_epic_key,
+                        action="skip",
+                    )
+                )
+
+        return items
+
+    async def _get_parent_epic_key(
+        self,
+        integration_id: UUID,
+        wbs_id: UUID,
+    ) -> str | None:
+        """Get the Jira Epic key for the parent WBS element."""
+        wbs_mapping = await self.mapping_repo.get_by_wbs(integration_id, wbs_id)
+        if wbs_mapping:
+            return wbs_mapping.jira_issue_key
+        return None
+
+    async def _create_issue(
+        self,
+        integration: JiraIntegration,
+        item: ActivitySyncItem,
+    ) -> JiraMapping:
+        """Create a Jira Issue for an Activity.
+
+        Args:
+            integration: Jira integration config
+            item: Activity sync item with parent epic info
+
+        Returns:
+            Created JiraMapping
+        """
+        activity = item.activity
+        description = self._build_issue_description(activity)
+
+        # Determine issue type based on activity
+        issue_type = "Task"
+        if activity.is_milestone:
+            issue_type = "Task"  # Could be customized
+
+        # Create Issue in Jira
+        issue = await self.jira_client.create_issue(
+            project_key=integration.project_key,
+            summary=activity.name,
+            issue_type=issue_type,
+            description=description,
+            epic_key=item.parent_epic_key,
+            labels=["defense-pm-tool", f"activity-{activity.code}"],
+        )
+
+        # Create mapping record
+        mapping_data: dict[str, Any] = {
+            "integration_id": integration.id,
+            "entity_type": EntityType.ACTIVITY.value,
+            "activity_id": activity.id,
+            "jira_issue_key": issue.key,
+            "jira_issue_id": issue.id,
+            "sync_direction": SyncDirection.BIDIRECTIONAL.value,
+            "last_synced_at": datetime.now(UTC),
+            "last_jira_updated": issue.updated,
+        }
+
+        mapping = await self.mapping_repo.create(mapping_data)
+
+        logger.info(
+            "activity_issue_created",
+            activity_id=str(activity.id),
+            activity_code=activity.code,
+            issue_key=issue.key,
+            epic_key=item.parent_epic_key,
+        )
+
+        return mapping
+
+    async def _update_issue(
+        self,
+        _integration: JiraIntegration,
+        activity: Activity,
+        mapping: JiraMapping | None,
+    ) -> JiraMapping | None:
+        """Update existing Jira Issue from Activity data.
+
+        Args:
+            _integration: Jira integration config (reserved for future use)
+            activity: Activity with updated data
+            mapping: Existing mapping to update
+
+        Returns:
+            Updated JiraMapping or None if no update needed
+        """
+        if mapping is None:
+            return None
+
+        # Build updated fields
+        description = self._build_issue_description(activity)
+
+        # Update Issue in Jira
+        await self.jira_client.update_issue(
+            issue_key=mapping.jira_issue_key,
+            summary=activity.name,
+            description=description,
+        )
+
+        # Update mapping record
+        mapping.last_synced_at = datetime.now(UTC)
+        await self.mapping_repo.update(mapping, {"last_synced_at": mapping.last_synced_at})
+
+        logger.info(
+            "activity_issue_updated",
+            activity_id=str(activity.id),
+            activity_code=activity.code,
+            issue_key=mapping.jira_issue_key,
+        )
+
+        return mapping
+
+    def _build_issue_description(self, activity: Activity) -> str:
+        """Build Issue description from Activity.
+
+        Includes:
+        - Activity code and schedule info
+        - Duration and dates
+        - Progress status
+        - Link back to Defense PM Tool
+        """
+        lines = [
+            f"*Activity Code:* {activity.code}",
+            f"*Duration:* {activity.duration} days",
+        ]
+
+        if activity.planned_start:
+            lines.append(f"*Planned Start:* {activity.planned_start}")
+        if activity.planned_finish:
+            lines.append(f"*Planned Finish:* {activity.planned_finish}")
+
+        if activity.early_start:
+            lines.append(f"*Early Start:* {activity.early_start}")
+        if activity.early_finish:
+            lines.append(f"*Early Finish:* {activity.early_finish}")
+
+        lines.append(f"\n*Progress:* {activity.percent_complete}%")
+
+        if activity.is_critical:
+            lines.append("\n_This activity is on the critical path._")
+
+        if activity.is_milestone:
+            lines.append("\n_This is a milestone._")
+
+        if activity.description:
+            lines.append(f"\n{activity.description}")
+
+        lines.append("\n---")
+        lines.append("_Synced from Defense PM Tool_")
+
+        return "\n".join(lines)
+
+    async def _get_mappings_for_pull(
+        self,
+        integration_id: UUID,
+        mapping_ids: list[UUID] | None = None,
+    ) -> list[JiraMapping]:
+        """Get mappings eligible for pull from Jira."""
+        all_mappings = await self.mapping_repo.get_by_integration(
+            integration_id, entity_type=EntityType.ACTIVITY.value
+        )
+
+        # Filter to specific IDs if provided
+        if mapping_ids:
+            all_mappings = [m for m in all_mappings if m.id in mapping_ids]
+
+        # Filter to mappings that allow pull
+        pullable = [
+            m
+            for m in all_mappings
+            if m.sync_direction
+            in (SyncDirection.FROM_JIRA.value, SyncDirection.BIDIRECTIONAL.value)
+        ]
+
+        return pullable
+
+    async def _pull_issue_to_activity(
+        self,
+        mapping: JiraMapping,
+    ) -> bool:
+        """Pull Issue data from Jira and update Activity if newer.
+
+        Uses last-write-wins conflict resolution based on timestamps.
+
+        Args:
+            mapping: Activity-Issue mapping
+
+        Returns:
+            True if Activity was updated, False if no update needed
+        """
+        if mapping.activity_id is None:
+            return False
+
+        # Fetch current Issue from Jira
+        issue = await self.jira_client.get_issue(mapping.jira_issue_key)
+
+        # Check if Jira has newer changes (conflict resolution)
+        if mapping.last_jira_updated and issue.updated <= mapping.last_jira_updated:
+            logger.debug(
+                "activity_pull_skipped_no_changes",
+                mapping_id=str(mapping.id),
+                jira_key=mapping.jira_issue_key,
+            )
+            return False
+
+        # Get Activity
+        activity = await self.activity_repo.get_by_id(mapping.activity_id)
+        if not activity:
+            logger.warning(
+                "activity_pull_activity_not_found",
+                mapping_id=str(mapping.id),
+                activity_id=str(mapping.activity_id),
+            )
+            return False
+
+        # Update Activity from Issue
+        update_data: dict[str, Any] = {"name": issue.summary}
+
+        # Map Jira status to percent_complete
+        jira_status = issue.status.lower()
+        if "done" in jira_status or "complete" in jira_status:
+            update_data["percent_complete"] = Decimal("100.00")
+        elif "progress" in jira_status and activity.percent_complete == Decimal("0.00"):
+            # Set to 50% if activity was not started but Jira shows in progress
+            update_data["percent_complete"] = Decimal("50.00")
+
+        await self.activity_repo.update(activity, update_data)
+
+        # Update mapping timestamps
+        mapping.last_synced_at = datetime.now(UTC)
+        mapping.last_jira_updated = issue.updated
+        await self.mapping_repo.update(
+            mapping,
+            {
+                "last_synced_at": mapping.last_synced_at,
+                "last_jira_updated": mapping.last_jira_updated,
+            },
+        )
+
+        logger.info(
+            "activity_pulled_from_jira",
+            activity_id=str(activity.id),
+            activity_code=activity.code,
+            issue_key=mapping.jira_issue_key,
+        )
+
+        return True
+
+    async def _sync_activity_progress(
+        self,
+        mapping: JiraMapping,
+        activity: Activity,
+    ) -> None:
+        """Sync activity progress to Jira Issue.
+
+        Updates status based on percent_complete:
+        - 0%: To Do
+        - 1-99%: In Progress
+        - 100%: Done
+        """
+        # Determine target status
+        if activity.percent_complete >= Decimal("100.00"):
+            target_status = JIRA_STATUS_MAPPINGS["completed"]
+        elif activity.percent_complete > Decimal("0.00"):
+            target_status = JIRA_STATUS_MAPPINGS["in_progress"]
+        else:
+            target_status = JIRA_STATUS_MAPPINGS["not_started"]
+
+        # Get current Jira status
+        issue = await self.jira_client.get_issue(mapping.jira_issue_key)
+
+        # Transition if needed
+        if issue.status.lower() != target_status.lower():
+            try:
+                await self.jira_client.transition_issue(mapping.jira_issue_key, target_status)
+                logger.info(
+                    "activity_status_transitioned",
+                    issue_key=mapping.jira_issue_key,
+                    from_status=issue.status,
+                    to_status=target_status,
+                )
+            except JiraSyncError as e:
+                # Log but don't fail - transition might not be available
+                logger.warning(
+                    "activity_status_transition_failed",
+                    issue_key=mapping.jira_issue_key,
+                    target_status=target_status,
+                    error=str(e),
+                )
+
+        # Update mapping
+        mapping.last_synced_at = datetime.now(UTC)
+        await self.mapping_repo.update(mapping, {"last_synced_at": mapping.last_synced_at})
+
+    async def _log_sync(
+        self,
+        integration_id: UUID,
+        sync_type: str,
+        status: str,
+        items_synced: int,
+        error_message: str | None = None,
+        duration_ms: int | None = None,
+        mapping_id: UUID | None = None,
+    ) -> None:
+        """Log sync operation to audit trail."""
+        log_data: dict[str, Any] = {
+            "integration_id": integration_id,
+            "mapping_id": mapping_id,
+            "sync_type": sync_type,
+            "status": status,
+            "items_synced": items_synced,
+            "error_message": error_message,
+            "duration_ms": duration_ms,
+        }
+
+        await self.sync_log_repo.create(log_data)
+
+    async def _update_integration_sync_time(
+        self,
+        integration: JiraIntegration,
+    ) -> None:
+        """Update integration's last_sync_at timestamp."""
+        await self.integration_repo.update(
+            integration,
+            {"last_sync_at": datetime.now(UTC)},
+        )

--- a/api/tests/unit/test_activity_sync_service.py
+++ b/api/tests/unit/test_activity_sync_service.py
@@ -1,0 +1,1414 @@
+"""Unit tests for Activity to Jira Issue sync service.
+
+Tests the ActivitySyncService with mocked repositories and Jira client.
+"""
+
+from datetime import UTC, datetime
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.services.jira_activity_sync import (
+    JIRA_STATUS_MAPPINGS,
+    ActivitySyncError,
+    ActivitySyncItem,
+    ActivitySyncService,
+    IntegrationNotFoundError,
+    ParentEpicNotFoundError,
+    SyncDisabledError,
+    SyncResult,
+)
+from src.services.jira_client import JiraIssueData, JiraSyncError
+
+
+class TestSyncResult:
+    """Tests for SyncResult dataclass."""
+
+    def test_default_values(self):
+        """SyncResult should have sensible defaults."""
+        result = SyncResult(success=True, items_synced=0, items_failed=0)
+        assert result.success is True
+        assert result.items_synced == 0
+        assert result.items_failed == 0
+        assert result.errors == []
+        assert result.created_mappings == []
+        assert result.updated_mappings == []
+        assert result.duration_ms == 0
+
+    def test_with_values(self):
+        """SyncResult should store all values."""
+        mapping_id = uuid4()
+        result = SyncResult(
+            success=False,
+            items_synced=5,
+            items_failed=2,
+            errors=["Error 1", "Error 2"],
+            created_mappings=[mapping_id],
+            updated_mappings=[],
+            duration_ms=1500,
+        )
+        assert result.success is False
+        assert result.items_synced == 5
+        assert result.items_failed == 2
+        assert len(result.errors) == 2
+        assert mapping_id in result.created_mappings
+
+
+class TestActivitySyncItem:
+    """Tests for ActivitySyncItem dataclass."""
+
+    def test_create_action(self):
+        """ActivitySyncItem should track create action."""
+        mock_activity = MagicMock()
+        item = ActivitySyncItem(
+            activity=mock_activity,
+            mapping=None,
+            parent_epic_key=None,
+            action="create",
+        )
+        assert item.action == "create"
+        assert item.mapping is None
+        assert item.jira_key is None
+        assert item.error is None
+
+    def test_update_action(self):
+        """ActivitySyncItem should track update action with mapping."""
+        mock_activity = MagicMock()
+        mock_mapping = MagicMock()
+        item = ActivitySyncItem(
+            activity=mock_activity,
+            mapping=mock_mapping,
+            parent_epic_key="PROJ-10",
+            action="update",
+            jira_key="PROJ-123",
+        )
+        assert item.action == "update"
+        assert item.mapping is mock_mapping
+        assert item.jira_key == "PROJ-123"
+        assert item.parent_epic_key == "PROJ-10"
+
+    def test_with_parent_epic(self):
+        """ActivitySyncItem should track parent epic key."""
+        mock_activity = MagicMock()
+        item = ActivitySyncItem(
+            activity=mock_activity,
+            mapping=None,
+            parent_epic_key="PROJ-5",
+            action="create",
+        )
+        assert item.parent_epic_key == "PROJ-5"
+
+
+class TestActivitySyncExceptions:
+    """Tests for custom Activity sync exceptions."""
+
+    def test_activity_sync_error(self):
+        """ActivitySyncError should store message and details."""
+        error = ActivitySyncError("Sync failed", {"reason": "timeout"})
+        assert str(error) == "Sync failed"
+        assert error.message == "Sync failed"
+        assert error.details == {"reason": "timeout"}
+
+    def test_activity_sync_error_default_details(self):
+        """ActivitySyncError should default to empty details."""
+        error = ActivitySyncError("Error")
+        assert error.details == {}
+
+    def test_integration_not_found_error(self):
+        """IntegrationNotFoundError should inherit from ActivitySyncError."""
+        error = IntegrationNotFoundError("Not found")
+        assert isinstance(error, ActivitySyncError)
+
+    def test_sync_disabled_error(self):
+        """SyncDisabledError should inherit from ActivitySyncError."""
+        error = SyncDisabledError("Disabled")
+        assert isinstance(error, ActivitySyncError)
+
+    def test_parent_epic_not_found_error(self):
+        """ParentEpicNotFoundError should inherit from ActivitySyncError."""
+        error = ParentEpicNotFoundError("No epic mapping")
+        assert isinstance(error, ActivitySyncError)
+
+
+class TestJiraStatusMappings:
+    """Tests for JIRA_STATUS_MAPPINGS constant."""
+
+    def test_status_mappings_exist(self):
+        """Should have all required status mappings."""
+        assert "not_started" in JIRA_STATUS_MAPPINGS
+        assert "in_progress" in JIRA_STATUS_MAPPINGS
+        assert "completed" in JIRA_STATUS_MAPPINGS
+
+    def test_status_mapping_values(self):
+        """Should map to correct Jira statuses."""
+        assert JIRA_STATUS_MAPPINGS["not_started"] == "To Do"
+        assert JIRA_STATUS_MAPPINGS["in_progress"] == "In Progress"
+        assert JIRA_STATUS_MAPPINGS["completed"] == "Done"
+
+
+class TestActivitySyncServiceInit:
+    """Tests for ActivitySyncService initialization."""
+
+    def test_init_stores_dependencies(self):
+        """Service should store all dependencies."""
+        mock_jira = MagicMock()
+        mock_integration_repo = MagicMock()
+        mock_mapping_repo = MagicMock()
+        mock_sync_log_repo = MagicMock()
+        mock_activity_repo = MagicMock()
+
+        service = ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+        assert service.jira_client is mock_jira
+        assert service.integration_repo is mock_integration_repo
+        assert service.mapping_repo is mock_mapping_repo
+        assert service.sync_log_repo is mock_sync_log_repo
+        assert service.activity_repo is mock_activity_repo
+
+
+class TestActivitySyncServiceGetIntegration:
+    """Tests for _get_integration method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an ActivitySyncService with mocked dependencies."""
+        mock_jira = MagicMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+
+        return ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_get_integration_success(self, service):
+        """Should return integration when found and enabled."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.sync_enabled = True
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        result = await service._get_integration(integration_id)
+
+        assert result is mock_integration
+        service.integration_repo.get_by_id.assert_called_once_with(integration_id)
+
+    @pytest.mark.asyncio
+    async def test_get_integration_not_found(self, service):
+        """Should raise IntegrationNotFoundError when not found."""
+        integration_id = uuid4()
+        service.integration_repo.get_by_id.return_value = None
+
+        with pytest.raises(IntegrationNotFoundError) as exc:
+            await service._get_integration(integration_id)
+
+        assert str(integration_id) in str(exc.value)
+
+    @pytest.mark.asyncio
+    async def test_get_integration_disabled(self, service):
+        """Should raise SyncDisabledError when sync disabled."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.sync_enabled = False
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        with pytest.raises(SyncDisabledError) as exc:
+            await service._get_integration(integration_id)
+
+        assert "disabled" in str(exc.value).lower()
+
+
+class TestActivitySyncServiceGetSyncableActivities:
+    """Tests for _get_syncable_activities method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an ActivitySyncService with mocked dependencies."""
+        mock_jira = MagicMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+
+        return ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+    @pytest.fixture
+    def sample_activities(self):
+        """Create sample activities."""
+        activities = []
+        for i in range(5):
+            activity = MagicMock()
+            activity.id = uuid4()
+            activity.code = f"ACT-{i:03d}"
+            activity.name = f"Activity {i}"
+            activity.duration = 5
+            activity.percent_complete = Decimal("0.00")
+            activities.append(activity)
+        return activities
+
+    @pytest.mark.asyncio
+    async def test_returns_all_activities(self, service, sample_activities):
+        """Should return all activities for program."""
+        program_id = uuid4()
+        service.activity_repo.get_by_program.return_value = sample_activities
+
+        result = await service._get_syncable_activities(program_id)
+
+        assert len(result) == 5
+        service.activity_repo.get_by_program.assert_called_once_with(program_id)
+
+    @pytest.mark.asyncio
+    async def test_filters_by_specific_ids(self, service, sample_activities):
+        """Should filter to specific activity IDs when provided."""
+        program_id = uuid4()
+        target_id = sample_activities[0].id
+        service.activity_repo.get_by_program.return_value = sample_activities
+
+        result = await service._get_syncable_activities(program_id, activity_ids=[target_id])
+
+        assert len(result) == 1
+        assert result[0].id == target_id
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_no_activities(self, service):
+        """Should return empty list when no activities."""
+        program_id = uuid4()
+        service.activity_repo.get_by_program.return_value = []
+
+        result = await service._get_syncable_activities(program_id)
+
+        assert len(result) == 0
+
+
+class TestActivitySyncServicePrepareSyncItems:
+    """Tests for _prepare_sync_items method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an ActivitySyncService with mocked dependencies."""
+        mock_jira = MagicMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+
+        return ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_create_action_for_unmapped(self, service):
+        """Should assign 'create' action for unmapped activity."""
+        integration_id = uuid4()
+        activity = MagicMock()
+        activity.id = uuid4()
+        activity.wbs_id = uuid4()
+        service.mapping_repo.get_by_activity.return_value = None
+        service.mapping_repo.get_by_wbs.return_value = None
+
+        result = await service._prepare_sync_items(integration_id, [activity])
+
+        assert len(result) == 1
+        assert result[0].action == "create"
+        assert result[0].mapping is None
+
+    @pytest.mark.asyncio
+    async def test_update_action_for_bidirectional_mapping(self, service):
+        """Should assign 'update' action for bidirectional mapping."""
+        integration_id = uuid4()
+        activity = MagicMock()
+        activity.id = uuid4()
+        activity.wbs_id = uuid4()
+        mapping = MagicMock()
+        mapping.sync_direction = "bidirectional"
+        service.mapping_repo.get_by_activity.return_value = mapping
+        service.mapping_repo.get_by_wbs.return_value = None
+
+        result = await service._prepare_sync_items(integration_id, [activity])
+
+        assert len(result) == 1
+        assert result[0].action == "update"
+        assert result[0].mapping is mapping
+
+    @pytest.mark.asyncio
+    async def test_update_action_for_to_jira_mapping(self, service):
+        """Should assign 'update' action for to_jira mapping."""
+        integration_id = uuid4()
+        activity = MagicMock()
+        activity.id = uuid4()
+        activity.wbs_id = uuid4()
+        mapping = MagicMock()
+        mapping.sync_direction = "to_jira"
+        service.mapping_repo.get_by_activity.return_value = mapping
+        service.mapping_repo.get_by_wbs.return_value = None
+
+        result = await service._prepare_sync_items(integration_id, [activity])
+
+        assert result[0].action == "update"
+
+    @pytest.mark.asyncio
+    async def test_skip_action_for_from_jira_mapping(self, service):
+        """Should assign 'skip' action for from_jira only mapping."""
+        integration_id = uuid4()
+        activity = MagicMock()
+        activity.id = uuid4()
+        activity.wbs_id = uuid4()
+        mapping = MagicMock()
+        mapping.sync_direction = "from_jira"
+        service.mapping_repo.get_by_activity.return_value = mapping
+        service.mapping_repo.get_by_wbs.return_value = None
+
+        result = await service._prepare_sync_items(integration_id, [activity])
+
+        assert result[0].action == "skip"
+
+    @pytest.mark.asyncio
+    async def test_includes_parent_epic_key(self, service):
+        """Should include parent epic key from WBS mapping."""
+        integration_id = uuid4()
+        activity = MagicMock()
+        activity.id = uuid4()
+        activity.wbs_id = uuid4()
+
+        wbs_mapping = MagicMock()
+        wbs_mapping.jira_issue_key = "PROJ-10"
+
+        service.mapping_repo.get_by_activity.return_value = None
+        service.mapping_repo.get_by_wbs.return_value = wbs_mapping
+
+        result = await service._prepare_sync_items(integration_id, [activity])
+
+        assert result[0].parent_epic_key == "PROJ-10"
+
+
+class TestActivitySyncServiceGetParentEpicKey:
+    """Tests for _get_parent_epic_key method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an ActivitySyncService with mocked dependencies."""
+        mock_jira = MagicMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+
+        return ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_epic_key_when_mapping_exists(self, service):
+        """Should return epic key from WBS mapping."""
+        integration_id = uuid4()
+        wbs_id = uuid4()
+
+        wbs_mapping = MagicMock()
+        wbs_mapping.jira_issue_key = "PROJ-10"
+        service.mapping_repo.get_by_wbs.return_value = wbs_mapping
+
+        result = await service._get_parent_epic_key(integration_id, wbs_id)
+
+        assert result == "PROJ-10"
+        service.mapping_repo.get_by_wbs.assert_called_once_with(integration_id, wbs_id)
+
+    @pytest.mark.asyncio
+    async def test_returns_none_when_no_mapping(self, service):
+        """Should return None when no WBS mapping."""
+        integration_id = uuid4()
+        wbs_id = uuid4()
+        service.mapping_repo.get_by_wbs.return_value = None
+
+        result = await service._get_parent_epic_key(integration_id, wbs_id)
+
+        assert result is None
+
+
+class TestActivitySyncServiceBuildIssueDescription:
+    """Tests for _build_issue_description method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an ActivitySyncService with mocked dependencies."""
+        mock_jira = MagicMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+
+        return ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+    def test_includes_activity_code_and_duration(self, service):
+        """Description should include activity code and duration."""
+        activity = MagicMock()
+        activity.code = "ACT-001"
+        activity.duration = 10
+        activity.planned_start = None
+        activity.planned_finish = None
+        activity.early_start = None
+        activity.early_finish = None
+        activity.percent_complete = Decimal("50.00")
+        activity.is_critical = False
+        activity.is_milestone = False
+        activity.description = None
+
+        result = service._build_issue_description(activity)
+
+        assert "*Activity Code:* ACT-001" in result
+        assert "*Duration:* 10 days" in result
+
+    def test_includes_dates_when_present(self, service):
+        """Description should include dates when available."""
+        from datetime import date
+
+        activity = MagicMock()
+        activity.code = "ACT-001"
+        activity.duration = 5
+        activity.planned_start = date(2026, 1, 15)
+        activity.planned_finish = date(2026, 1, 20)
+        activity.early_start = date(2026, 1, 15)
+        activity.early_finish = date(2026, 1, 20)
+        activity.percent_complete = Decimal("0.00")
+        activity.is_critical = False
+        activity.is_milestone = False
+        activity.description = None
+
+        result = service._build_issue_description(activity)
+
+        assert "*Planned Start:*" in result
+        assert "*Planned Finish:*" in result
+        assert "*Early Start:*" in result
+        assert "*Early Finish:*" in result
+
+    def test_includes_progress(self, service):
+        """Description should include progress percentage."""
+        activity = MagicMock()
+        activity.code = "ACT-001"
+        activity.duration = 5
+        activity.planned_start = None
+        activity.planned_finish = None
+        activity.early_start = None
+        activity.early_finish = None
+        activity.percent_complete = Decimal("75.00")
+        activity.is_critical = False
+        activity.is_milestone = False
+        activity.description = None
+
+        result = service._build_issue_description(activity)
+
+        assert "*Progress:* 75.00%" in result
+
+    def test_includes_critical_path_indicator(self, service):
+        """Description should indicate if on critical path."""
+        activity = MagicMock()
+        activity.code = "ACT-001"
+        activity.duration = 5
+        activity.planned_start = None
+        activity.planned_finish = None
+        activity.early_start = None
+        activity.early_finish = None
+        activity.percent_complete = Decimal("0.00")
+        activity.is_critical = True
+        activity.is_milestone = False
+        activity.description = None
+
+        result = service._build_issue_description(activity)
+
+        assert "critical path" in result.lower()
+
+    def test_includes_milestone_indicator(self, service):
+        """Description should indicate if milestone."""
+        activity = MagicMock()
+        activity.code = "ACT-001"
+        activity.duration = 0
+        activity.planned_start = None
+        activity.planned_finish = None
+        activity.early_start = None
+        activity.early_finish = None
+        activity.percent_complete = Decimal("0.00")
+        activity.is_critical = False
+        activity.is_milestone = True
+        activity.description = None
+
+        result = service._build_issue_description(activity)
+
+        assert "milestone" in result.lower()
+
+    def test_includes_description_when_present(self, service):
+        """Description should include activity description."""
+        activity = MagicMock()
+        activity.code = "ACT-001"
+        activity.duration = 5
+        activity.planned_start = None
+        activity.planned_finish = None
+        activity.early_start = None
+        activity.early_finish = None
+        activity.percent_complete = Decimal("0.00")
+        activity.is_critical = False
+        activity.is_milestone = False
+        activity.description = "Complete detailed design review"
+
+        result = service._build_issue_description(activity)
+
+        assert "Complete detailed design review" in result
+
+    def test_includes_sync_attribution(self, service):
+        """Description should include sync attribution."""
+        activity = MagicMock()
+        activity.code = "ACT-001"
+        activity.duration = 5
+        activity.planned_start = None
+        activity.planned_finish = None
+        activity.early_start = None
+        activity.early_finish = None
+        activity.percent_complete = Decimal("0.00")
+        activity.is_critical = False
+        activity.is_milestone = False
+        activity.description = None
+
+        result = service._build_issue_description(activity)
+
+        assert "Defense PM Tool" in result
+
+
+class TestActivitySyncServiceCreateIssue:
+    """Tests for _create_issue method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an ActivitySyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+
+        return ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_creates_issue_in_jira(self, service):
+        """Should call jira_client.create_issue with correct params."""
+        integration = MagicMock()
+        integration.id = uuid4()
+        integration.project_key = "PROJ"
+
+        activity = MagicMock()
+        activity.id = uuid4()
+        activity.code = "ACT-001"
+        activity.name = "Design Review"
+        activity.duration = 5
+        activity.planned_start = None
+        activity.planned_finish = None
+        activity.early_start = None
+        activity.early_finish = None
+        activity.percent_complete = Decimal("0.00")
+        activity.is_critical = False
+        activity.is_milestone = False
+        activity.description = None
+
+        item = ActivitySyncItem(
+            activity=activity,
+            mapping=None,
+            parent_epic_key="PROJ-10",
+            action="create",
+        )
+
+        now = datetime.now(UTC)
+        issue_data = JiraIssueData(
+            key="PROJ-123",
+            id="10123",
+            summary="Design Review",
+            description=None,
+            issue_type="Task",
+            status="To Do",
+            assignee=None,
+            created=now,
+            updated=now,
+        )
+        service.jira_client.create_issue.return_value = issue_data
+
+        mock_mapping = MagicMock()
+        mock_mapping.id = uuid4()
+        service.mapping_repo.create.return_value = mock_mapping
+
+        result = await service._create_issue(integration, item)
+
+        service.jira_client.create_issue.assert_called_once()
+        call_kwargs = service.jira_client.create_issue.call_args[1]
+        assert call_kwargs["project_key"] == "PROJ"
+        assert call_kwargs["summary"] == "Design Review"
+        assert call_kwargs["issue_type"] == "Task"
+        assert call_kwargs["epic_key"] == "PROJ-10"
+        assert "defense-pm-tool" in call_kwargs["labels"]
+
+    @pytest.mark.asyncio
+    async def test_creates_mapping_record(self, service):
+        """Should create JiraMapping record."""
+        integration = MagicMock()
+        integration.id = uuid4()
+        integration.project_key = "PROJ"
+
+        activity = MagicMock()
+        activity.id = uuid4()
+        activity.code = "ACT-001"
+        activity.name = "Design Review"
+        activity.duration = 5
+        activity.planned_start = None
+        activity.planned_finish = None
+        activity.early_start = None
+        activity.early_finish = None
+        activity.percent_complete = Decimal("0.00")
+        activity.is_critical = False
+        activity.is_milestone = False
+        activity.description = None
+
+        item = ActivitySyncItem(
+            activity=activity,
+            mapping=None,
+            parent_epic_key=None,
+            action="create",
+        )
+
+        now = datetime.now(UTC)
+        issue_data = JiraIssueData(
+            key="PROJ-123",
+            id="10123",
+            summary="Design Review",
+            description=None,
+            issue_type="Task",
+            status="To Do",
+            assignee=None,
+            created=now,
+            updated=now,
+        )
+        service.jira_client.create_issue.return_value = issue_data
+
+        mock_mapping = MagicMock()
+        mock_mapping.id = uuid4()
+        service.mapping_repo.create.return_value = mock_mapping
+
+        result = await service._create_issue(integration, item)
+
+        assert result is mock_mapping
+        service.mapping_repo.create.assert_called_once()
+
+
+class TestActivitySyncServiceUpdateIssue:
+    """Tests for _update_issue method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an ActivitySyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+
+        return ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_returns_none_for_no_mapping(self, service):
+        """Should return None when mapping is None."""
+        integration = MagicMock()
+        activity = MagicMock()
+
+        result = await service._update_issue(integration, activity, None)
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_updates_issue_in_jira(self, service):
+        """Should call jira_client.update_issue."""
+        integration = MagicMock()
+        integration.id = uuid4()
+        integration.project_key = "PROJ"
+
+        activity = MagicMock()
+        activity.id = uuid4()
+        activity.code = "ACT-001"
+        activity.name = "Updated Design Review"
+        activity.duration = 5
+        activity.planned_start = None
+        activity.planned_finish = None
+        activity.early_start = None
+        activity.early_finish = None
+        activity.percent_complete = Decimal("50.00")
+        activity.is_critical = False
+        activity.is_milestone = False
+        activity.description = "Updated description"
+
+        mapping = MagicMock()
+        mapping.id = uuid4()
+        mapping.jira_issue_key = "PROJ-123"
+        mapping.last_synced_at = None
+
+        result = await service._update_issue(integration, activity, mapping)
+
+        service.jira_client.update_issue.assert_called_once()
+        call_kwargs = service.jira_client.update_issue.call_args[1]
+        assert call_kwargs["issue_key"] == "PROJ-123"
+        assert call_kwargs["summary"] == "Updated Design Review"
+
+    @pytest.mark.asyncio
+    async def test_updates_mapping_timestamp(self, service):
+        """Should update mapping's last_synced_at."""
+        integration = MagicMock()
+        integration.id = uuid4()
+        integration.project_key = "PROJ"
+
+        activity = MagicMock()
+        activity.id = uuid4()
+        activity.code = "ACT-001"
+        activity.name = "Design Review"
+        activity.duration = 5
+        activity.planned_start = None
+        activity.planned_finish = None
+        activity.early_start = None
+        activity.early_finish = None
+        activity.percent_complete = Decimal("0.00")
+        activity.is_critical = False
+        activity.is_milestone = False
+        activity.description = None
+
+        mapping = MagicMock()
+        mapping.id = uuid4()
+        mapping.jira_issue_key = "PROJ-123"
+
+        result = await service._update_issue(integration, activity, mapping)
+
+        service.mapping_repo.update.assert_called_once()
+        assert result is mapping
+
+
+class TestActivitySyncServiceSyncActivitiesToJira:
+    """Tests for sync_activities_to_jira method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an ActivitySyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+
+        return ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_for_missing_integration(self, service):
+        """Should raise IntegrationNotFoundError."""
+        integration_id = uuid4()
+        service.integration_repo.get_by_id.return_value = None
+
+        with pytest.raises(IntegrationNotFoundError):
+            await service.sync_activities_to_jira(integration_id)
+
+    @pytest.mark.asyncio
+    async def test_raises_for_disabled_sync(self, service):
+        """Should raise SyncDisabledError."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.sync_enabled = False
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        with pytest.raises(SyncDisabledError):
+            await service.sync_activities_to_jira(integration_id)
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_result_for_no_activities(self, service):
+        """Should return empty result when no activities."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        service.integration_repo.get_by_id.return_value = mock_integration
+        service.activity_repo.get_by_program.return_value = []
+
+        result = await service.sync_activities_to_jira(integration_id)
+
+        assert result.success is True
+        assert result.items_synced == 0
+        assert result.items_failed == 0
+
+    @pytest.mark.asyncio
+    async def test_creates_issues_for_unmapped_activities(self, service):
+        """Should create Issues for unmapped activities."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        mock_integration.project_key = "PROJ"
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        activity = MagicMock()
+        activity.id = uuid4()
+        activity.wbs_id = uuid4()
+        activity.code = "ACT-001"
+        activity.name = "Design Review"
+        activity.duration = 5
+        activity.planned_start = None
+        activity.planned_finish = None
+        activity.early_start = None
+        activity.early_finish = None
+        activity.percent_complete = Decimal("0.00")
+        activity.is_critical = False
+        activity.is_milestone = False
+        activity.description = None
+        service.activity_repo.get_by_program.return_value = [activity]
+        service.mapping_repo.get_by_activity.return_value = None
+        service.mapping_repo.get_by_wbs.return_value = None
+
+        now = datetime.now(UTC)
+        issue_data = JiraIssueData(
+            key="PROJ-123",
+            id="10123",
+            summary="Design Review",
+            description=None,
+            issue_type="Task",
+            status="To Do",
+            assignee=None,
+            created=now,
+            updated=now,
+        )
+        service.jira_client.create_issue.return_value = issue_data
+
+        mock_mapping = MagicMock()
+        mock_mapping.id = uuid4()
+        service.mapping_repo.create.return_value = mock_mapping
+
+        result = await service.sync_activities_to_jira(integration_id)
+
+        assert result.success is True
+        assert result.items_synced == 1
+        assert len(result.created_mappings) == 1
+
+    @pytest.mark.asyncio
+    async def test_logs_sync_operation(self, service):
+        """Should create sync log entry."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        mock_integration.project_key = "PROJ"
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        activity = MagicMock()
+        activity.id = uuid4()
+        activity.wbs_id = uuid4()
+        activity.code = "ACT-001"
+        activity.name = "Design Review"
+        activity.duration = 5
+        activity.planned_start = None
+        activity.planned_finish = None
+        activity.early_start = None
+        activity.early_finish = None
+        activity.percent_complete = Decimal("0.00")
+        activity.is_critical = False
+        activity.is_milestone = False
+        activity.description = None
+        service.activity_repo.get_by_program.return_value = [activity]
+        service.mapping_repo.get_by_activity.return_value = None
+        service.mapping_repo.get_by_wbs.return_value = None
+
+        now = datetime.now(UTC)
+        issue_data = JiraIssueData(
+            key="PROJ-123",
+            id="10123",
+            summary="Design Review",
+            description=None,
+            issue_type="Task",
+            status="To Do",
+            assignee=None,
+            created=now,
+            updated=now,
+        )
+        service.jira_client.create_issue.return_value = issue_data
+
+        mock_mapping = MagicMock()
+        mock_mapping.id = uuid4()
+        service.mapping_repo.create.return_value = mock_mapping
+
+        await service.sync_activities_to_jira(integration_id)
+
+        service.sync_log_repo.create.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_handles_partial_failure(self, service):
+        """Should report partial success on some failures."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        mock_integration.project_key = "PROJ"
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        # Create two activities
+        activity1 = MagicMock()
+        activity1.id = uuid4()
+        activity1.wbs_id = uuid4()
+        activity1.code = "ACT-001"
+        activity1.name = "Activity 1"
+        activity1.duration = 5
+        activity1.planned_start = None
+        activity1.planned_finish = None
+        activity1.early_start = None
+        activity1.early_finish = None
+        activity1.percent_complete = Decimal("0.00")
+        activity1.is_critical = False
+        activity1.is_milestone = False
+        activity1.description = None
+
+        activity2 = MagicMock()
+        activity2.id = uuid4()
+        activity2.wbs_id = uuid4()
+        activity2.code = "ACT-002"
+        activity2.name = "Activity 2"
+        activity2.duration = 5
+        activity2.planned_start = None
+        activity2.planned_finish = None
+        activity2.early_start = None
+        activity2.early_finish = None
+        activity2.percent_complete = Decimal("0.00")
+        activity2.is_critical = False
+        activity2.is_milestone = False
+        activity2.description = None
+
+        service.activity_repo.get_by_program.return_value = [activity1, activity2]
+        service.mapping_repo.get_by_activity.return_value = None
+        service.mapping_repo.get_by_wbs.return_value = None
+
+        # First succeeds, second fails
+        now = datetime.now(UTC)
+        issue_data = JiraIssueData(
+            key="PROJ-123",
+            id="10123",
+            summary="Activity 1",
+            description=None,
+            issue_type="Task",
+            status="To Do",
+            assignee=None,
+            created=now,
+            updated=now,
+        )
+        service.jira_client.create_issue.side_effect = [
+            issue_data,
+            JiraSyncError("Jira API error"),
+        ]
+
+        mock_mapping = MagicMock()
+        mock_mapping.id = uuid4()
+        service.mapping_repo.create.return_value = mock_mapping
+
+        result = await service.sync_activities_to_jira(integration_id)
+
+        assert result.success is True  # Partial success
+        assert result.items_synced == 1
+        assert result.items_failed == 1
+        assert len(result.errors) == 1
+
+
+class TestActivitySyncServicePullFromJira:
+    """Tests for pull_from_jira method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an ActivitySyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+
+        return ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_raises_for_missing_integration(self, service):
+        """Should raise IntegrationNotFoundError."""
+        integration_id = uuid4()
+        service.integration_repo.get_by_id.return_value = None
+
+        with pytest.raises(IntegrationNotFoundError):
+            await service.pull_from_jira(integration_id)
+
+    @pytest.mark.asyncio
+    async def test_returns_empty_for_no_mappings(self, service):
+        """Should return empty result when no pullable mappings."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        service.integration_repo.get_by_id.return_value = mock_integration
+        service.mapping_repo.get_by_integration.return_value = []
+
+        result = await service.pull_from_jira(integration_id)
+
+        assert result.success is True
+        assert result.items_synced == 0
+
+    @pytest.mark.asyncio
+    async def test_filters_pullable_mappings(self, service):
+        """Should only pull from bidirectional or from_jira mappings."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        # Create mapping with to_jira direction (should be skipped)
+        mapping = MagicMock()
+        mapping.id = uuid4()
+        mapping.sync_direction = "to_jira"
+        service.mapping_repo.get_by_integration.return_value = [mapping]
+
+        result = await service.pull_from_jira(integration_id)
+
+        # No pullable mappings
+        assert result.items_synced == 0
+
+    @pytest.mark.asyncio
+    async def test_updates_activity_from_issue(self, service):
+        """Should update Activity when Jira has newer changes."""
+        integration_id = uuid4()
+        activity_id = uuid4()
+
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        mapping = MagicMock()
+        mapping.id = uuid4()
+        mapping.activity_id = activity_id
+        mapping.jira_issue_key = "PROJ-123"
+        mapping.sync_direction = "bidirectional"
+        mapping.last_jira_updated = datetime(2026, 1, 1, tzinfo=UTC)
+        service.mapping_repo.get_by_integration.return_value = [mapping]
+
+        activity = MagicMock()
+        activity.id = activity_id
+        activity.code = "ACT-001"
+        activity.percent_complete = Decimal("0.00")
+        service.activity_repo.get_by_id.return_value = activity
+
+        # Jira has newer update
+        issue_data = JiraIssueData(
+            key="PROJ-123",
+            id="10123",
+            summary="Updated Activity Name",
+            description="New description",
+            issue_type="Task",
+            status="In Progress",
+            assignee=None,
+            created=datetime(2026, 1, 1, tzinfo=UTC),
+            updated=datetime(2026, 1, 18, tzinfo=UTC),  # Newer
+        )
+        service.jira_client.get_issue.return_value = issue_data
+
+        result = await service.pull_from_jira(integration_id)
+
+        assert result.items_synced == 1
+        service.activity_repo.update.assert_called_once()
+
+
+class TestActivitySyncServiceSyncProgress:
+    """Tests for sync_progress method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an ActivitySyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+
+        return ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_syncs_progress_to_jira(self, service):
+        """Should sync activity progress to Jira."""
+        integration_id = uuid4()
+        activity_id = uuid4()
+
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.program_id = uuid4()
+        service.integration_repo.get_by_id.return_value = mock_integration
+
+        mapping = MagicMock()
+        mapping.id = uuid4()
+        mapping.activity_id = activity_id
+        mapping.jira_issue_key = "PROJ-123"
+        service.mapping_repo.get_by_integration.return_value = [mapping]
+
+        activity = MagicMock()
+        activity.id = activity_id
+        activity.code = "ACT-001"
+        activity.percent_complete = Decimal("50.00")
+        service.activity_repo.get_by_id.return_value = activity
+
+        issue_data = JiraIssueData(
+            key="PROJ-123",
+            id="10123",
+            summary="Activity",
+            description=None,
+            issue_type="Task",
+            status="To Do",
+            assignee=None,
+            created=datetime.now(UTC),
+            updated=datetime.now(UTC),
+        )
+        service.jira_client.get_issue.return_value = issue_data
+
+        result = await service.sync_progress(integration_id)
+
+        assert result.success is True
+        # Should have attempted to transition the status
+        service.jira_client.transition_issue.assert_called_once()
+
+
+class TestActivitySyncServiceSyncActivityProgress:
+    """Tests for _sync_activity_progress method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an ActivitySyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+
+        return ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_transitions_to_done_at_100_percent(self, service):
+        """Should transition to Done when percent_complete is 100."""
+        mapping = MagicMock()
+        mapping.jira_issue_key = "PROJ-123"
+        mapping.last_synced_at = None
+
+        activity = MagicMock()
+        activity.percent_complete = Decimal("100.00")
+
+        issue_data = JiraIssueData(
+            key="PROJ-123",
+            id="10123",
+            summary="Activity",
+            description=None,
+            issue_type="Task",
+            status="In Progress",
+            assignee=None,
+            created=datetime.now(UTC),
+            updated=datetime.now(UTC),
+        )
+        service.jira_client.get_issue.return_value = issue_data
+
+        await service._sync_activity_progress(mapping, activity)
+
+        service.jira_client.transition_issue.assert_called_once_with("PROJ-123", "Done")
+
+    @pytest.mark.asyncio
+    async def test_transitions_to_in_progress_for_partial(self, service):
+        """Should transition to In Progress when 0 < percent_complete < 100."""
+        mapping = MagicMock()
+        mapping.jira_issue_key = "PROJ-123"
+        mapping.last_synced_at = None
+
+        activity = MagicMock()
+        activity.percent_complete = Decimal("50.00")
+
+        issue_data = JiraIssueData(
+            key="PROJ-123",
+            id="10123",
+            summary="Activity",
+            description=None,
+            issue_type="Task",
+            status="To Do",
+            assignee=None,
+            created=datetime.now(UTC),
+            updated=datetime.now(UTC),
+        )
+        service.jira_client.get_issue.return_value = issue_data
+
+        await service._sync_activity_progress(mapping, activity)
+
+        service.jira_client.transition_issue.assert_called_once_with("PROJ-123", "In Progress")
+
+    @pytest.mark.asyncio
+    async def test_no_transition_when_already_correct(self, service):
+        """Should not transition when already in correct status."""
+        mapping = MagicMock()
+        mapping.jira_issue_key = "PROJ-123"
+        mapping.last_synced_at = None
+
+        activity = MagicMock()
+        activity.percent_complete = Decimal("50.00")
+
+        issue_data = JiraIssueData(
+            key="PROJ-123",
+            id="10123",
+            summary="Activity",
+            description=None,
+            issue_type="Task",
+            status="In Progress",  # Already correct
+            assignee=None,
+            created=datetime.now(UTC),
+            updated=datetime.now(UTC),
+        )
+        service.jira_client.get_issue.return_value = issue_data
+
+        await service._sync_activity_progress(mapping, activity)
+
+        service.jira_client.transition_issue.assert_not_called()
+
+
+class TestActivitySyncServiceLogSync:
+    """Tests for _log_sync method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an ActivitySyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+
+        return ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_creates_sync_log_entry(self, service):
+        """Should create sync log with all parameters."""
+        integration_id = uuid4()
+        mapping_id = uuid4()
+
+        await service._log_sync(
+            integration_id=integration_id,
+            sync_type="push",
+            status="success",
+            items_synced=5,
+            error_message=None,
+            duration_ms=1500,
+            mapping_id=mapping_id,
+        )
+
+        service.sync_log_repo.create.assert_called_once()
+
+
+class TestActivitySyncServiceUpdateIntegrationSyncTime:
+    """Tests for _update_integration_sync_time method."""
+
+    @pytest.fixture
+    def service(self):
+        """Create an ActivitySyncService with mocked dependencies."""
+        mock_jira = AsyncMock()
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+
+        return ActivitySyncService(
+            jira_client=mock_jira,
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            sync_log_repo=mock_sync_log_repo,
+            activity_repo=mock_activity_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_updates_last_sync_at(self, service):
+        """Should update integration's last_sync_at."""
+        integration = MagicMock()
+        integration.id = uuid4()
+
+        await service._update_integration_sync_time(integration)
+
+        service.integration_repo.update.assert_called_once()
+        call_args = service.integration_repo.update.call_args
+        assert call_args[0][0] is integration  # First arg is the model
+        assert "last_sync_at" in call_args[0][1]  # Second arg is the update data


### PR DESCRIPTION
## Summary
- Add ActivitySyncService for bidirectional sync between Activities and Jira Issues (Tasks/Stories)
- Create Jira integration API endpoints for sync operations
- Add comprehensive request/response schemas for Jira integration
- Implement progress sync with Jira status transitions (To Do → In Progress → Done)
- Link activities to parent Epics through WBS mappings

## Changes
- `api/src/services/jira_activity_sync.py` - Activity sync service with push/pull operations
- `api/src/api/v1/endpoints/jira_integration.py` - REST API endpoints for Jira integration
- `api/src/schemas/jira_integration.py` - Pydantic schemas for request/response validation
- `api/tests/unit/test_activity_sync_service.py` - 54 unit tests for the sync service

## Test plan
- [x] 54 new unit tests for ActivitySyncService
- [x] All 1766 unit tests passing
- [x] mypy type checking passes
- [x] ruff linting passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)