### PR TITLE
Feature: Jira Webhook Handler

### DIFF
--- a/api/src/api/v1/endpoints/jira_webhook.py
+++ b/api/src/api/v1/endpoints/jira_webhook.py
@@ -1,0 +1,331 @@
+"""Jira Webhook API endpoints.
+
+Receives webhooks from Jira for real-time updates:
+- Issue created/updated/deleted events
+- Status change propagation
+- Bidirectional sync support
+
+Security:
+- Signature verification using webhook secret
+- Rate limiting recommended at infrastructure level
+"""
+
+from typing import Annotated, Any
+from uuid import UUID
+
+import structlog
+from fastapi import APIRouter, Header, HTTPException, Request, status
+
+from src.config import settings
+from src.core.deps import DbSession
+from src.repositories.activity import ActivityRepository
+from src.repositories.jira_integration import JiraIntegrationRepository
+from src.repositories.jira_mapping import JiraMappingRepository
+from src.repositories.jira_sync_log import JiraSyncLogRepository
+from src.repositories.wbs import WBSElementRepository
+from src.schemas.jira_integration import JiraWebhookPayload
+from src.services.jira_webhook_processor import (
+    JiraWebhookProcessor,
+)
+
+logger = structlog.get_logger(__name__)
+
+router = APIRouter()
+
+
+class WebhookResponse:
+    """Response model for webhook processing."""
+
+    def __init__(
+        self,
+        success: bool,
+        message: str,
+        event_type: str | None = None,
+        issue_key: str | None = None,
+        action: str | None = None,
+    ):
+        self.success = success
+        self.message = message
+        self.event_type = event_type
+        self.issue_key = issue_key
+        self.action = action
+
+    def to_dict(self) -> dict[str, Any]:
+        """Convert to dictionary for JSON response."""
+        return {
+            "success": self.success,
+            "message": self.message,
+            "event_type": self.event_type,
+            "issue_key": self.issue_key,
+            "action": self.action,
+        }
+
+
+@router.post(
+    "/jira",
+    status_code=status.HTTP_200_OK,
+    responses={
+        200: {"description": "Webhook processed successfully"},
+        400: {"description": "Invalid webhook payload"},
+        401: {"description": "Invalid webhook signature"},
+        500: {"description": "Internal processing error"},
+    },
+)
+async def receive_jira_webhook(
+    request: Request,
+    db: DbSession,
+    x_hub_signature: Annotated[str | None, Header(alias="X-Hub-Signature")] = None,
+    x_atlassian_webhook_identifier: Annotated[
+        str | None, Header(alias="X-Atlassian-Webhook-Identifier")
+    ] = None,
+) -> dict[str, Any]:
+    """
+    Receive and process Jira webhooks.
+
+    This endpoint handles incoming webhooks from Jira Cloud for real-time
+    synchronization. It processes the following events:
+    - jira:issue_created - New issues linked to mappings
+    - jira:issue_updated - Updates to linked issues (status, summary, etc.)
+    - jira:issue_deleted - Soft-deletes mappings for deleted issues
+
+    Headers:
+    - X-Hub-Signature: HMAC-SHA256 signature for verification (optional based on config)
+    - X-Atlassian-Webhook-Identifier: Unique webhook ID from Jira
+
+    Note: For security, configure a webhook secret in Jira and set
+    JIRA_WEBHOOK_SECRET in environment to enable signature verification.
+    """
+    # Get raw body for signature verification
+    raw_body = await request.body()
+
+    # Verify signature if secret is configured
+    webhook_secret = getattr(settings, "jira_webhook_secret", None)
+    if webhook_secret:
+        processor = _create_processor(db)
+        if not processor.verify_signature(raw_body, x_hub_signature or "", webhook_secret):
+            logger.warning(
+                "webhook_signature_invalid",
+                webhook_id=x_atlassian_webhook_identifier,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid webhook signature",
+            )
+
+    # Parse payload
+    try:
+        payload_dict = await request.json()
+        payload = JiraWebhookPayload(**payload_dict)
+    except Exception as e:
+        logger.error(
+            "webhook_parse_error",
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid webhook payload: {e}",
+        ) from e
+
+    logger.info(
+        "webhook_received",
+        event=payload.webhookEvent,
+        webhook_id=x_atlassian_webhook_identifier,
+        issue_key=payload.issue.get("key") if payload.issue else None,
+    )
+
+    # Process the webhook
+    processor = _create_processor(db)
+
+    try:
+        result = await processor.process_webhook(payload)
+        await db.commit()
+
+        logger.info(
+            "webhook_processed",
+            event=payload.webhookEvent,
+            success=result.success,
+            action=result.action_taken,
+            issue_key=result.issue_key,
+            duration_ms=result.duration_ms,
+        )
+
+        return {
+            "success": result.success,
+            "message": "Webhook processed successfully" if result.success else result.error_message,
+            "event_type": result.event_type,
+            "issue_key": result.issue_key,
+            "action": result.action_taken,
+        }
+
+    except Exception as e:
+        logger.error(
+            "webhook_processing_error",
+            event=payload.webhookEvent,
+            error=str(e),
+        )
+        # Return 200 to prevent Jira from retrying for unrecoverable errors
+        # but indicate failure in response body
+        return {
+            "success": False,
+            "message": f"Processing error: {e}",
+            "event_type": payload.webhookEvent,
+            "issue_key": payload.issue.get("key") if payload.issue else None,
+            "action": None,
+        }
+
+
+@router.post(
+    "/jira/{integration_id}",
+    status_code=status.HTTP_200_OK,
+    responses={
+        200: {"description": "Webhook processed successfully"},
+        400: {"description": "Invalid webhook payload"},
+        401: {"description": "Invalid webhook signature"},
+        404: {"description": "Integration not found"},
+        500: {"description": "Internal processing error"},
+    },
+)
+async def receive_jira_webhook_for_integration(
+    request: Request,
+    db: DbSession,
+    integration_id: UUID,
+    x_hub_signature: Annotated[str | None, Header(alias="X-Hub-Signature")] = None,
+    x_atlassian_webhook_identifier: Annotated[
+        str | None, Header(alias="X-Atlassian-Webhook-Identifier")
+    ] = None,
+) -> dict[str, Any]:
+    """
+    Receive Jira webhooks for a specific integration.
+
+    This endpoint is an alternative that includes the integration ID in the URL,
+    useful when you have integration-specific webhook URLs configured in Jira.
+
+    Args:
+        integration_id: UUID of the Jira integration
+    """
+    # Get raw body for signature verification
+    raw_body = await request.body()
+
+    # Verify integration exists
+    integration_repo = JiraIntegrationRepository(db)
+    integration = await integration_repo.get(integration_id)
+    if not integration:
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail=f"Integration {integration_id} not found",
+        )
+
+    # Verify signature if configured
+    # Could use per-integration secrets in the future
+    webhook_secret = getattr(settings, "jira_webhook_secret", None)
+    if webhook_secret:
+        processor = _create_processor(db)
+        if not processor.verify_signature(raw_body, x_hub_signature or "", webhook_secret):
+            logger.warning(
+                "webhook_signature_invalid",
+                integration_id=str(integration_id),
+                webhook_id=x_atlassian_webhook_identifier,
+            )
+            raise HTTPException(
+                status_code=status.HTTP_401_UNAUTHORIZED,
+                detail="Invalid webhook signature",
+            )
+
+    # Parse payload
+    try:
+        payload_dict = await request.json()
+        payload = JiraWebhookPayload(**payload_dict)
+    except Exception as e:
+        logger.error(
+            "webhook_parse_error",
+            integration_id=str(integration_id),
+            error=str(e),
+        )
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Invalid webhook payload: {e}",
+        ) from e
+
+    logger.info(
+        "webhook_received",
+        event=payload.webhookEvent,
+        integration_id=str(integration_id),
+        webhook_id=x_atlassian_webhook_identifier,
+        issue_key=payload.issue.get("key") if payload.issue else None,
+    )
+
+    # Process the webhook with known integration
+    processor = _create_processor(db)
+
+    try:
+        result = await processor.process_webhook(payload, integration_id=integration_id)
+        await db.commit()
+
+        logger.info(
+            "webhook_processed",
+            event=payload.webhookEvent,
+            integration_id=str(integration_id),
+            success=result.success,
+            action=result.action_taken,
+            issue_key=result.issue_key,
+            duration_ms=result.duration_ms,
+        )
+
+        return {
+            "success": result.success,
+            "message": "Webhook processed successfully" if result.success else result.error_message,
+            "event_type": result.event_type,
+            "issue_key": result.issue_key,
+            "action": result.action_taken,
+        }
+
+    except Exception as e:
+        logger.error(
+            "webhook_processing_error",
+            event=payload.webhookEvent,
+            integration_id=str(integration_id),
+            error=str(e),
+        )
+        return {
+            "success": False,
+            "message": f"Processing error: {e}",
+            "event_type": payload.webhookEvent,
+            "issue_key": payload.issue.get("key") if payload.issue else None,
+            "action": None,
+        }
+
+
+@router.get(
+    "/jira/health",
+    status_code=status.HTTP_200_OK,
+)
+async def webhook_health_check() -> dict[str, Any]:
+    """
+    Health check endpoint for webhook receiver.
+
+    Use this endpoint to verify the webhook receiver is operational.
+    Jira can also use this for connectivity testing.
+    """
+    return {
+        "status": "healthy",
+        "service": "jira-webhook-receiver",
+        "signature_verification": bool(getattr(settings, "jira_webhook_secret", None)),
+    }
+
+
+def _create_processor(db: DbSession) -> JiraWebhookProcessor:
+    """Create a JiraWebhookProcessor with all dependencies.
+
+    Args:
+        db: Database session
+
+    Returns:
+        Configured JiraWebhookProcessor instance
+    """
+    return JiraWebhookProcessor(
+        integration_repo=JiraIntegrationRepository(db),
+        mapping_repo=JiraMappingRepository(db),
+        activity_repo=ActivityRepository(db),
+        wbs_repo=WBSElementRepository(db),
+        sync_log_repo=JiraSyncLogRepository(db),
+    )

--- a/api/src/api/v1/router.py
+++ b/api/src/api/v1/router.py
@@ -10,6 +10,7 @@ from src.api.v1.endpoints import (
     evms,
     import_export,
     jira_integration,
+    jira_webhook,
     management_reserve,
     programs,
     reports,
@@ -111,4 +112,10 @@ api_router.include_router(
     jira_integration.router,
     prefix="/jira",
     tags=["Jira Integration"],
+)
+
+api_router.include_router(
+    jira_webhook.router,
+    prefix="/webhooks",
+    tags=["Webhooks"],
 )

--- a/api/src/services/__init__.py
+++ b/api/src/services/__init__.py
@@ -6,12 +6,14 @@ from src.services.jira_activity_sync import ActivitySyncService
 from src.services.jira_client import JiraClient
 from src.services.jira_variance_alert import VarianceAlertService
 from src.services.jira_wbs_sync import WBSSyncService
+from src.services.jira_webhook_processor import JiraWebhookProcessor
 
 __all__ = [
     "ActivitySyncService",
     "CPMEngine",
     "EVMSCalculator",
     "JiraClient",
+    "JiraWebhookProcessor",
     "VarianceAlertService",
     "WBSSyncService",
 ]

--- a/api/src/services/jira_webhook_processor.py
+++ b/api/src/services/jira_webhook_processor.py
@@ -1,0 +1,780 @@
+"""Jira Webhook Processing Service.
+
+Handles incoming webhooks from Jira for real-time updates:
+- Issue created → Create/link mapping
+- Issue updated → Update activity/WBS
+- Issue deleted → Mark mapping as inactive
+
+Usage:
+    processor = JiraWebhookProcessor(
+        integration_repo=integration_repo,
+        mapping_repo=mapping_repo,
+        activity_repo=activity_repo,
+        wbs_repo=wbs_repo,
+        sync_log_repo=sync_log_repo,
+    )
+    result = await processor.process_webhook(payload)
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import time
+from dataclasses import dataclass, field
+from datetime import UTC, datetime
+from decimal import Decimal
+from typing import TYPE_CHECKING, Any
+
+import structlog
+
+from src.models.jira_mapping import EntityType, SyncDirection
+from src.models.jira_sync_log import SyncStatus, SyncType
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from src.models.jira_integration import JiraIntegration
+    from src.models.jira_mapping import JiraMapping
+    from src.repositories.activity import ActivityRepository
+    from src.repositories.jira_integration import JiraIntegrationRepository
+    from src.repositories.jira_mapping import JiraMappingRepository
+    from src.repositories.jira_sync_log import JiraSyncLogRepository
+    from src.repositories.wbs import WBSElementRepository
+    from src.schemas.jira_integration import JiraWebhookPayload
+
+
+logger = structlog.get_logger(__name__)
+
+
+class WebhookProcessingError(Exception):
+    """Base exception for webhook processing errors."""
+
+    def __init__(self, message: str, details: dict[str, Any] | None = None):
+        self.message = message
+        self.details = details or {}
+        super().__init__(message)
+
+
+class WebhookSignatureError(WebhookProcessingError):
+    """Webhook signature verification failed."""
+
+    pass
+
+
+class WebhookConfigError(WebhookProcessingError):
+    """Webhook configuration error."""
+
+    pass
+
+
+class IntegrationNotFoundError(WebhookProcessingError):
+    """No matching integration found for webhook."""
+
+    pass
+
+
+# Jira webhook event types
+WEBHOOK_EVENT_ISSUE_CREATED = "jira:issue_created"
+WEBHOOK_EVENT_ISSUE_UPDATED = "jira:issue_updated"
+WEBHOOK_EVENT_ISSUE_DELETED = "jira:issue_deleted"
+
+# Status to percent complete mapping (reverse of what we send to Jira)
+JIRA_STATUS_TO_PERCENT: dict[str, Decimal] = {
+    "To Do": Decimal("0"),
+    "Open": Decimal("0"),
+    "Backlog": Decimal("0"),
+    "In Progress": Decimal("50"),
+    "In Review": Decimal("75"),
+    "Done": Decimal("100"),
+    "Closed": Decimal("100"),
+    "Resolved": Decimal("100"),
+}
+
+
+@dataclass
+class WebhookResult:
+    """Result of processing a webhook."""
+
+    success: bool
+    event_type: str
+    issue_key: str | None = None
+    entity_type: str | None = None
+    entity_id: UUID | None = None
+    action_taken: str | None = None
+    error_message: str | None = None
+    duration_ms: int = 0
+
+
+@dataclass
+class BatchWebhookResult:
+    """Result of batch webhook processing."""
+
+    success: bool
+    webhooks_processed: int
+    webhooks_failed: int
+    results: list[WebhookResult] = field(default_factory=list)
+    errors: list[str] = field(default_factory=list)
+    duration_ms: int = 0
+
+
+class JiraWebhookProcessor:
+    """
+    Service for processing Jira webhooks.
+
+    Handles real-time updates from Jira:
+    - Issue updates propagate to linked activities/WBS
+    - Status changes update percent complete
+    - Deletions mark mappings as inactive
+
+    Attributes:
+        integration_repo: Repository for Jira integrations
+        mapping_repo: Repository for entity mappings
+        activity_repo: Repository for activities
+        wbs_repo: Repository for WBS elements
+        sync_log_repo: Repository for sync audit logs
+    """
+
+    def __init__(
+        self,
+        integration_repo: JiraIntegrationRepository,
+        mapping_repo: JiraMappingRepository,
+        activity_repo: ActivityRepository,
+        wbs_repo: WBSElementRepository,
+        sync_log_repo: JiraSyncLogRepository,
+    ) -> None:
+        """Initialize webhook processor.
+
+        Args:
+            integration_repo: Repository for Jira integrations
+            mapping_repo: Repository for entity mappings
+            activity_repo: Repository for activities
+            wbs_repo: Repository for WBS elements
+            sync_log_repo: Repository for sync audit logs
+        """
+        self.integration_repo = integration_repo
+        self.mapping_repo = mapping_repo
+        self.activity_repo = activity_repo
+        self.wbs_repo = wbs_repo
+        self.sync_log_repo = sync_log_repo
+
+    def verify_signature(
+        self,
+        payload: bytes,
+        signature: str,
+        secret: str,
+    ) -> bool:
+        """Verify webhook signature for security.
+
+        Jira Cloud uses HMAC-SHA256 signatures.
+
+        Args:
+            payload: Raw webhook payload bytes
+            signature: Signature from X-Hub-Signature header
+            secret: Webhook secret configured in Jira
+
+        Returns:
+            True if signature is valid
+        """
+        if not signature or not secret:
+            return False
+
+        # Jira uses sha256=<signature> format
+        if signature.startswith("sha256="):
+            signature = signature[7:]
+
+        expected = hmac.new(
+            secret.encode("utf-8"),
+            payload,
+            hashlib.sha256,
+        ).hexdigest()
+
+        return hmac.compare_digest(expected, signature)
+
+    async def process_webhook(
+        self,
+        payload: JiraWebhookPayload,
+        integration_id: UUID | None = None,
+    ) -> WebhookResult:
+        """Process a single webhook event.
+
+        Args:
+            payload: Parsed webhook payload
+            integration_id: Optional integration ID (if known)
+
+        Returns:
+            WebhookResult with processing details
+        """
+        start_time = time.time()
+        event_type = payload.webhookEvent
+
+        try:
+            # Validate and extract webhook context
+            validation = await self._validate_webhook(
+                payload, integration_id, event_type, start_time
+            )
+            if isinstance(validation, WebhookResult):
+                return validation
+
+            # Unpack validated context
+            issue, issue_key, integration, mapping = validation
+
+            # Route to appropriate handler
+            result = await self._route_webhook_event(
+                event_type, integration, mapping, issue, payload, issue_key
+            )
+
+            result.duration_ms = int((time.time() - start_time) * 1000)
+
+            # Log the sync operation
+            await self._log_sync(
+                integration_id=integration.id,
+                mapping_id=mapping.id,
+                sync_type=SyncType.WEBHOOK.value,
+                status=SyncStatus.SUCCESS.value if result.success else SyncStatus.FAILED.value,
+                items_synced=1 if result.success else 0,
+                error_message=result.error_message,
+                duration_ms=result.duration_ms,
+            )
+
+            return result
+
+        except Exception as e:
+            duration_ms = int((time.time() - start_time) * 1000)
+            logger.error(
+                "webhook_processing_error",
+                event=event_type,
+                error=str(e),
+            )
+            return WebhookResult(
+                success=False,
+                event_type=event_type,
+                error_message=str(e),
+                duration_ms=duration_ms,
+            )
+
+    async def _validate_webhook(  # noqa: PLR0911
+        self,
+        payload: JiraWebhookPayload,
+        integration_id: UUID | None,
+        event_type: str,
+        start_time: float,
+    ) -> WebhookResult | tuple[dict[str, Any], str, JiraIntegration, JiraMapping]:
+        """Validate webhook payload and find matching context.
+
+        Returns:
+            WebhookResult if validation fails (early exit reason), or
+            tuple of (issue, issue_key, integration, mapping) if valid.
+        """
+        # Extract issue information
+        issue = payload.issue
+        if not issue:
+            return WebhookResult(
+                success=False,
+                event_type=event_type,
+                error_message="No issue data in webhook payload",
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
+
+        issue_key = issue.get("key")
+        project_key = issue.get("fields", {}).get("project", {}).get("key")
+
+        if not issue_key or not project_key:
+            return WebhookResult(
+                success=False,
+                event_type=event_type,
+                error_message="Missing issue key or project key",
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
+
+        # Find matching integration
+        integration = await self._find_integration(
+            integration_id=integration_id,
+            project_key=project_key,
+        )
+
+        if not integration:
+            logger.debug(
+                "webhook_no_matching_integration",
+                project_key=project_key,
+                issue_key=issue_key,
+            )
+            return WebhookResult(
+                success=True,
+                event_type=event_type,
+                issue_key=issue_key,
+                action_taken="ignored_no_integration",
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
+
+        # Check if sync is enabled
+        if not integration.sync_enabled:
+            return WebhookResult(
+                success=True,
+                event_type=event_type,
+                issue_key=issue_key,
+                action_taken="ignored_sync_disabled",
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
+
+        # Find mapping for this issue
+        mapping = await self.mapping_repo.get_by_jira_key(
+            integration_id=integration.id,
+            jira_issue_key=issue_key,
+        )
+
+        if not mapping:
+            logger.debug(
+                "webhook_no_mapping",
+                issue_key=issue_key,
+                webhook_event=event_type,
+            )
+            return WebhookResult(
+                success=True,
+                event_type=event_type,
+                issue_key=issue_key,
+                action_taken="ignored_no_mapping",
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
+
+        # Check sync direction allows from_jira updates
+        if mapping.sync_direction == SyncDirection.TO_JIRA.value:
+            return WebhookResult(
+                success=True,
+                event_type=event_type,
+                issue_key=issue_key,
+                entity_type=mapping.entity_type,
+                action_taken="ignored_sync_direction",
+                duration_ms=int((time.time() - start_time) * 1000),
+            )
+
+        # All validations passed - return validated context
+        return (issue, issue_key, integration, mapping)
+
+    async def _route_webhook_event(
+        self,
+        event_type: str,
+        integration: JiraIntegration,
+        mapping: JiraMapping,
+        issue: dict[str, Any],
+        payload: JiraWebhookPayload,
+        issue_key: str,
+    ) -> WebhookResult:
+        """Route webhook event to appropriate handler."""
+        if event_type == WEBHOOK_EVENT_ISSUE_CREATED:
+            return await self._handle_issue_created(integration, mapping, issue, payload)
+        elif event_type == WEBHOOK_EVENT_ISSUE_UPDATED:
+            return await self._handle_issue_updated(integration, mapping, issue, payload)
+        elif event_type == WEBHOOK_EVENT_ISSUE_DELETED:
+            return await self._handle_issue_deleted(integration, mapping, issue, payload)
+        else:
+            return WebhookResult(
+                success=True,
+                event_type=event_type,
+                issue_key=issue_key,
+                action_taken="ignored_unsupported_event",
+            )
+
+    async def _find_integration(
+        self,
+        integration_id: UUID | None = None,
+        project_key: str | None = None,
+    ) -> JiraIntegration | None:
+        """Find matching integration for webhook.
+
+        Args:
+            integration_id: Direct integration ID (if known)
+            project_key: Jira project key to search by
+
+        Returns:
+            JiraIntegration or None
+        """
+        if integration_id:
+            return await self.integration_repo.get(integration_id)
+
+        if project_key:
+            # Search active integrations for matching project key
+            integrations = await self.integration_repo.get_active_integrations()
+            for integration in integrations:
+                if integration.project_key == project_key:
+                    return integration
+
+        return None
+
+    async def _handle_issue_created(
+        self,
+        integration: JiraIntegration,
+        mapping: JiraMapping,
+        issue: dict[str, Any],
+        payload: JiraWebhookPayload,
+    ) -> WebhookResult:
+        """Handle jira:issue_created event.
+
+        For created events, we typically just update the mapping's
+        last_jira_updated timestamp since the issue was created externally.
+        """
+        issue_key = issue.get("key", "")
+
+        # Update mapping timestamp
+        await self.mapping_repo.update(
+            mapping,
+            {"last_jira_updated": datetime.now(UTC)},
+        )
+
+        logger.info(
+            "webhook_issue_created_processed",
+            issue_key=issue_key,
+            entity_type=mapping.entity_type,
+            integration_id=str(integration.id),
+            webhook_event=payload.webhookEvent,
+        )
+
+        return WebhookResult(
+            success=True,
+            event_type=WEBHOOK_EVENT_ISSUE_CREATED,
+            issue_key=issue_key,
+            entity_type=mapping.entity_type,
+            entity_id=mapping.activity_id or mapping.wbs_id,
+            action_taken="mapping_updated",
+        )
+
+    async def _handle_issue_updated(
+        self,
+        integration: JiraIntegration,
+        mapping: JiraMapping,
+        issue: dict[str, Any],
+        payload: JiraWebhookPayload,
+    ) -> WebhookResult:
+        """Handle jira:issue_updated event.
+
+        Updates the linked entity based on issue changes:
+        - Status changes → Update percent complete (for activities)
+        - Summary changes → Update name
+        - Description changes → Update description (for WBS)
+        """
+        issue_key = issue.get("key", "")
+        fields = issue.get("fields", {})
+        changelog = payload.changelog
+
+        logger.debug(
+            "webhook_issue_update_processing",
+            issue_key=issue_key,
+            integration_id=str(integration.id),
+        )
+
+        # Update mapping timestamp
+        await self.mapping_repo.update(
+            mapping,
+            {"last_jira_updated": datetime.now(UTC)},
+        )
+
+        # Determine what changed
+        status_changed = False
+        new_status = None
+
+        if changelog and changelog.get("items"):
+            for item in changelog["items"]:
+                if item.get("field") == "status":
+                    status_changed = True
+                    new_status = item.get("toString")
+                    break
+
+        # If no changelog, get current status from fields
+        if not status_changed:
+            status_obj = fields.get("status", {})
+            new_status = status_obj.get("name")
+
+        # Handle based on entity type
+        if mapping.entity_type == EntityType.ACTIVITY.value:
+            return await self._update_activity_from_issue(
+                mapping=mapping,
+                issue_key=issue_key,
+                fields=fields,
+                status_changed=status_changed,
+                new_status=new_status,
+            )
+        elif mapping.entity_type == EntityType.WBS.value:
+            return await self._update_wbs_from_issue(
+                mapping=mapping,
+                issue_key=issue_key,
+                fields=fields,
+            )
+
+        return WebhookResult(
+            success=True,
+            event_type=WEBHOOK_EVENT_ISSUE_UPDATED,
+            issue_key=issue_key,
+            entity_type=mapping.entity_type,
+            action_taken="no_update_needed",
+        )
+
+    async def _update_activity_from_issue(
+        self,
+        mapping: JiraMapping,
+        issue_key: str,
+        fields: dict[str, Any],
+        status_changed: bool,
+        new_status: str | None,
+    ) -> WebhookResult:
+        """Update activity from Jira issue changes.
+
+        Args:
+            mapping: Entity mapping
+            issue_key: Jira issue key
+            fields: Issue fields
+            status_changed: Whether status was changed
+            new_status: New status name (if changed)
+
+        Returns:
+            WebhookResult
+        """
+        if not mapping.activity_id:
+            return WebhookResult(
+                success=False,
+                event_type=WEBHOOK_EVENT_ISSUE_UPDATED,
+                issue_key=issue_key,
+                entity_type=EntityType.ACTIVITY.value,
+                error_message="Mapping has no activity_id",
+            )
+
+        activity = await self.activity_repo.get(mapping.activity_id)
+        if not activity:
+            return WebhookResult(
+                success=False,
+                event_type=WEBHOOK_EVENT_ISSUE_UPDATED,
+                issue_key=issue_key,
+                entity_type=EntityType.ACTIVITY.value,
+                error_message=f"Activity {mapping.activity_id} not found",
+            )
+
+        update_data: dict[str, Any] = {}
+        action_parts: list[str] = []
+
+        # Update name from summary
+        summary = fields.get("summary")
+        if summary and summary != activity.name:
+            update_data["name"] = summary
+            action_parts.append("name")
+
+        # Update percent complete from status
+        if status_changed and new_status:
+            new_percent = self._status_to_percent(new_status)
+            if new_percent is not None and new_percent != activity.percent_complete:
+                update_data["percent_complete"] = new_percent
+                action_parts.append(f"progress={new_percent}%")
+
+        if update_data:
+            await self.activity_repo.update(activity, update_data)
+            action = f"updated_{'+'.join(action_parts)}"
+        else:
+            action = "no_changes"
+
+        logger.info(
+            "webhook_activity_updated",
+            issue_key=issue_key,
+            activity_id=str(mapping.activity_id),
+            changes=action_parts,
+        )
+
+        return WebhookResult(
+            success=True,
+            event_type=WEBHOOK_EVENT_ISSUE_UPDATED,
+            issue_key=issue_key,
+            entity_type=EntityType.ACTIVITY.value,
+            entity_id=mapping.activity_id,
+            action_taken=action,
+        )
+
+    async def _update_wbs_from_issue(
+        self,
+        mapping: JiraMapping,
+        issue_key: str,
+        fields: dict[str, Any],
+    ) -> WebhookResult:
+        """Update WBS element from Jira issue (Epic) changes.
+
+        Args:
+            mapping: Entity mapping
+            issue_key: Jira issue key
+            fields: Issue fields
+
+        Returns:
+            WebhookResult
+        """
+        if not mapping.wbs_id:
+            return WebhookResult(
+                success=False,
+                event_type=WEBHOOK_EVENT_ISSUE_UPDATED,
+                issue_key=issue_key,
+                entity_type=EntityType.WBS.value,
+                error_message="Mapping has no wbs_id",
+            )
+
+        wbs = await self.wbs_repo.get(mapping.wbs_id)
+        if not wbs:
+            return WebhookResult(
+                success=False,
+                event_type=WEBHOOK_EVENT_ISSUE_UPDATED,
+                issue_key=issue_key,
+                entity_type=EntityType.WBS.value,
+                error_message=f"WBS {mapping.wbs_id} not found",
+            )
+
+        update_data: dict[str, Any] = {}
+        action_parts: list[str] = []
+
+        # Update name from summary
+        summary = fields.get("summary")
+        if summary and summary != wbs.name:
+            update_data["name"] = summary
+            action_parts.append("name")
+
+        # Update description
+        description = fields.get("description")
+        if description:
+            # Jira description can be complex (ADF format), extract text
+            desc_text = self._extract_description_text(description)
+            if desc_text and desc_text != wbs.description:
+                update_data["description"] = desc_text
+                action_parts.append("description")
+
+        if update_data:
+            await self.wbs_repo.update(wbs, update_data)
+            action = f"updated_{'+'.join(action_parts)}"
+        else:
+            action = "no_changes"
+
+        logger.info(
+            "webhook_wbs_updated",
+            issue_key=issue_key,
+            wbs_id=str(mapping.wbs_id),
+            changes=action_parts,
+        )
+
+        return WebhookResult(
+            success=True,
+            event_type=WEBHOOK_EVENT_ISSUE_UPDATED,
+            issue_key=issue_key,
+            entity_type=EntityType.WBS.value,
+            entity_id=mapping.wbs_id,
+            action_taken=action,
+        )
+
+    async def _handle_issue_deleted(
+        self,
+        integration: JiraIntegration,
+        mapping: JiraMapping,
+        issue: dict[str, Any],
+        payload: JiraWebhookPayload,
+    ) -> WebhookResult:
+        """Handle jira:issue_deleted event.
+
+        Soft-deletes the mapping to preserve audit trail.
+        Does not delete the linked entity.
+        """
+        issue_key = issue.get("key", "")
+
+        # Soft delete the mapping
+        await self.mapping_repo.delete(mapping.id)
+
+        logger.info(
+            "webhook_issue_deleted_processed",
+            issue_key=issue_key,
+            entity_type=mapping.entity_type,
+            entity_id=str(mapping.activity_id or mapping.wbs_id),
+            integration_id=str(integration.id),
+            webhook_event=payload.webhookEvent,
+        )
+
+        return WebhookResult(
+            success=True,
+            event_type=WEBHOOK_EVENT_ISSUE_DELETED,
+            issue_key=issue_key,
+            entity_type=mapping.entity_type,
+            entity_id=mapping.activity_id or mapping.wbs_id,
+            action_taken="mapping_deleted",
+        )
+
+    def _status_to_percent(self, status: str) -> Decimal | None:
+        """Convert Jira status to percent complete.
+
+        Args:
+            status: Jira status name
+
+        Returns:
+            Decimal percent complete, or None if unknown status
+        """
+        # Check direct mapping
+        if status in JIRA_STATUS_TO_PERCENT:
+            return JIRA_STATUS_TO_PERCENT[status]
+
+        # Check case-insensitive
+        status_lower = status.lower()
+        for jira_status, percent in JIRA_STATUS_TO_PERCENT.items():
+            if jira_status.lower() == status_lower:
+                return percent
+
+        # Common patterns
+        if "done" in status_lower or "complete" in status_lower or "closed" in status_lower:
+            return Decimal("100")
+        if "progress" in status_lower or "active" in status_lower:
+            return Decimal("50")
+        if "todo" in status_lower or "open" in status_lower or "new" in status_lower:
+            return Decimal("0")
+
+        logger.warning(
+            "webhook_unknown_status",
+            status=status,
+        )
+        return None
+
+    def _extract_description_text(self, description: Any) -> str | None:
+        """Extract plain text from Jira description.
+
+        Jira Cloud uses Atlassian Document Format (ADF) for descriptions.
+        This extracts the text content.
+
+        Args:
+            description: Description field (string or ADF dict)
+
+        Returns:
+            Plain text description or None
+        """
+        if isinstance(description, str):
+            return description
+
+        if isinstance(description, dict):
+            # ADF format - extract text from content
+            content = description.get("content", [])
+            texts = []
+            for block in content:
+                if block.get("type") == "paragraph":
+                    for item in block.get("content", []):
+                        if item.get("type") == "text":
+                            texts.append(item.get("text", ""))
+            return "\n".join(texts) if texts else None
+
+        return None
+
+    async def _log_sync(
+        self,
+        integration_id: UUID,
+        mapping_id: UUID | None,
+        sync_type: str,
+        status: str,
+        items_synced: int,
+        error_message: str | None = None,
+        duration_ms: int | None = None,
+    ) -> None:
+        """Log sync operation to audit trail."""
+        log_data: dict[str, Any] = {
+            "integration_id": integration_id,
+            "mapping_id": mapping_id,
+            "sync_type": sync_type,
+            "status": status,
+            "items_synced": items_synced,
+            "error_message": error_message,
+            "duration_ms": duration_ms,
+        }
+
+        await self.sync_log_repo.create(log_data)

--- a/api/tests/unit/test_jira_webhook.py
+++ b/api/tests/unit/test_jira_webhook.py
@@ -1,0 +1,852 @@
+"""Unit tests for Jira Webhook processing.
+
+Tests the JiraWebhookProcessor with mocked repositories.
+"""
+
+import hashlib
+import hmac
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.schemas.jira_integration import JiraWebhookPayload
+from src.services.jira_webhook_processor import (
+    JIRA_STATUS_TO_PERCENT,
+    BatchWebhookResult,
+    IntegrationNotFoundError,
+    JiraWebhookProcessor,
+    WebhookConfigError,
+    WebhookProcessingError,
+    WebhookResult,
+    WebhookSignatureError,
+)
+
+
+class TestWebhookResult:
+    """Tests for WebhookResult dataclass."""
+
+    def test_default_values(self):
+        """WebhookResult should have sensible defaults."""
+        result = WebhookResult(success=True, event_type="jira:issue_updated")
+        assert result.success is True
+        assert result.event_type == "jira:issue_updated"
+        assert result.issue_key is None
+        assert result.entity_type is None
+        assert result.entity_id is None
+        assert result.action_taken is None
+        assert result.error_message is None
+        assert result.duration_ms == 0
+
+    def test_with_values(self):
+        """WebhookResult should store all values."""
+        entity_id = uuid4()
+        result = WebhookResult(
+            success=True,
+            event_type="jira:issue_updated",
+            issue_key="PROJ-123",
+            entity_type="activity",
+            entity_id=entity_id,
+            action_taken="updated_progress=50%",
+            duration_ms=150,
+        )
+        assert result.issue_key == "PROJ-123"
+        assert result.entity_type == "activity"
+        assert result.entity_id == entity_id
+        assert result.action_taken == "updated_progress=50%"
+        assert result.duration_ms == 150
+
+    def test_failure_result(self):
+        """WebhookResult should store failure details."""
+        result = WebhookResult(
+            success=False,
+            event_type="jira:issue_updated",
+            error_message="Mapping not found",
+        )
+        assert result.success is False
+        assert result.error_message == "Mapping not found"
+
+
+class TestBatchWebhookResult:
+    """Tests for BatchWebhookResult dataclass."""
+
+    def test_default_values(self):
+        """BatchWebhookResult should have sensible defaults."""
+        result = BatchWebhookResult(success=True, webhooks_processed=0, webhooks_failed=0)
+        assert result.success is True
+        assert result.webhooks_processed == 0
+        assert result.webhooks_failed == 0
+        assert result.results == []
+        assert result.errors == []
+        assert result.duration_ms == 0
+
+    def test_with_values(self):
+        """BatchWebhookResult should store all values."""
+        webhook_result = WebhookResult(success=True, event_type="jira:issue_updated")
+        result = BatchWebhookResult(
+            success=True,
+            webhooks_processed=5,
+            webhooks_failed=1,
+            results=[webhook_result],
+            errors=["Error 1"],
+            duration_ms=500,
+        )
+        assert result.webhooks_processed == 5
+        assert result.webhooks_failed == 1
+        assert len(result.results) == 1
+        assert len(result.errors) == 1
+
+
+class TestWebhookExceptions:
+    """Tests for custom webhook exceptions."""
+
+    def test_webhook_processing_error(self):
+        """WebhookProcessingError should store message and details."""
+        error = WebhookProcessingError("Processing failed", {"reason": "timeout"})
+        assert str(error) == "Processing failed"
+        assert error.message == "Processing failed"
+        assert error.details == {"reason": "timeout"}
+
+    def test_webhook_processing_error_default_details(self):
+        """WebhookProcessingError should default to empty details."""
+        error = WebhookProcessingError("Error")
+        assert error.details == {}
+
+    def test_webhook_signature_error(self):
+        """WebhookSignatureError should inherit from WebhookProcessingError."""
+        error = WebhookSignatureError("Invalid signature")
+        assert isinstance(error, WebhookProcessingError)
+
+    def test_webhook_config_error(self):
+        """WebhookConfigError should inherit from WebhookProcessingError."""
+        error = WebhookConfigError("Missing config")
+        assert isinstance(error, WebhookProcessingError)
+
+    def test_integration_not_found_error(self):
+        """IntegrationNotFoundError should inherit from WebhookProcessingError."""
+        error = IntegrationNotFoundError("Not found")
+        assert isinstance(error, WebhookProcessingError)
+
+
+class TestJiraStatusMapping:
+    """Tests for Jira status to percent mapping."""
+
+    def test_standard_statuses_mapped(self):
+        """Standard Jira statuses should be mapped."""
+        assert JIRA_STATUS_TO_PERCENT["To Do"] == Decimal("0")
+        assert JIRA_STATUS_TO_PERCENT["In Progress"] == Decimal("50")
+        assert JIRA_STATUS_TO_PERCENT["Done"] == Decimal("100")
+
+    def test_all_statuses_have_valid_percentages(self):
+        """All mapped statuses should have valid percentages."""
+        for _status, percent in JIRA_STATUS_TO_PERCENT.items():
+            assert Decimal("0") <= percent <= Decimal("100")
+
+
+class TestJiraWebhookProcessorInit:
+    """Tests for JiraWebhookProcessor initialization."""
+
+    def test_init_stores_dependencies(self):
+        """Processor should store all dependencies."""
+        mock_integration_repo = MagicMock()
+        mock_mapping_repo = MagicMock()
+        mock_activity_repo = MagicMock()
+        mock_wbs_repo = MagicMock()
+        mock_sync_log_repo = MagicMock()
+
+        processor = JiraWebhookProcessor(
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            activity_repo=mock_activity_repo,
+            wbs_repo=mock_wbs_repo,
+            sync_log_repo=mock_sync_log_repo,
+        )
+
+        assert processor.integration_repo is mock_integration_repo
+        assert processor.mapping_repo is mock_mapping_repo
+        assert processor.activity_repo is mock_activity_repo
+        assert processor.wbs_repo is mock_wbs_repo
+        assert processor.sync_log_repo is mock_sync_log_repo
+
+
+class TestJiraWebhookProcessorVerifySignature:
+    """Tests for verify_signature method."""
+
+    @pytest.fixture
+    def processor(self):
+        """Create a JiraWebhookProcessor with mocked dependencies."""
+        return JiraWebhookProcessor(
+            integration_repo=AsyncMock(),
+            mapping_repo=AsyncMock(),
+            activity_repo=AsyncMock(),
+            wbs_repo=AsyncMock(),
+            sync_log_repo=AsyncMock(),
+        )
+
+    def test_valid_signature(self, processor):
+        """Should return True for valid signature."""
+        payload = b'{"test": "data"}'
+        secret = "my-webhook-secret"
+        expected = hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+        signature = f"sha256={expected}"
+
+        result = processor.verify_signature(payload, signature, secret)
+        assert result is True
+
+    def test_invalid_signature(self, processor):
+        """Should return False for invalid signature."""
+        payload = b'{"test": "data"}'
+        secret = "my-webhook-secret"
+        signature = "sha256=invalid_signature"
+
+        result = processor.verify_signature(payload, signature, secret)
+        assert result is False
+
+    def test_missing_signature(self, processor):
+        """Should return False for missing signature."""
+        payload = b'{"test": "data"}'
+        secret = "my-webhook-secret"
+
+        result = processor.verify_signature(payload, "", secret)
+        assert result is False
+
+    def test_missing_secret(self, processor):
+        """Should return False for missing secret."""
+        payload = b'{"test": "data"}'
+        signature = "sha256=something"
+
+        result = processor.verify_signature(payload, signature, "")
+        assert result is False
+
+    def test_signature_without_prefix(self, processor):
+        """Should handle signature without sha256= prefix."""
+        payload = b'{"test": "data"}'
+        secret = "my-webhook-secret"
+        expected = hmac.new(secret.encode("utf-8"), payload, hashlib.sha256).hexdigest()
+
+        result = processor.verify_signature(payload, expected, secret)
+        assert result is True
+
+
+class TestJiraWebhookProcessorStatusToPercent:
+    """Tests for _status_to_percent method."""
+
+    @pytest.fixture
+    def processor(self):
+        """Create a JiraWebhookProcessor with mocked dependencies."""
+        return JiraWebhookProcessor(
+            integration_repo=AsyncMock(),
+            mapping_repo=AsyncMock(),
+            activity_repo=AsyncMock(),
+            wbs_repo=AsyncMock(),
+            sync_log_repo=AsyncMock(),
+        )
+
+    def test_known_status_to_do(self, processor):
+        """Should map 'To Do' to 0%."""
+        assert processor._status_to_percent("To Do") == Decimal("0")
+
+    def test_known_status_in_progress(self, processor):
+        """Should map 'In Progress' to 50%."""
+        assert processor._status_to_percent("In Progress") == Decimal("50")
+
+    def test_known_status_done(self, processor):
+        """Should map 'Done' to 100%."""
+        assert processor._status_to_percent("Done") == Decimal("100")
+
+    def test_case_insensitive_matching(self, processor):
+        """Should match statuses case-insensitively."""
+        assert processor._status_to_percent("TO DO") == Decimal("0")
+        assert processor._status_to_percent("in progress") == Decimal("50")
+        assert processor._status_to_percent("DONE") == Decimal("100")
+
+    def test_pattern_matching_done(self, processor):
+        """Should recognize 'done' pattern in status."""
+        assert processor._status_to_percent("Marked as Done") == Decimal("100")
+        assert processor._status_to_percent("Complete") == Decimal("100")
+
+    def test_pattern_matching_in_progress(self, processor):
+        """Should recognize 'progress' pattern in status."""
+        assert processor._status_to_percent("Work In Progress") == Decimal("50")
+        assert processor._status_to_percent("Active Development") == Decimal("50")
+
+    def test_pattern_matching_todo(self, processor):
+        """Should recognize 'todo' pattern in status."""
+        assert processor._status_to_percent("New Task") == Decimal("0")
+        assert processor._status_to_percent("Open Issue") == Decimal("0")
+
+    def test_unknown_status_returns_none(self, processor):
+        """Should return None for completely unknown status."""
+        result = processor._status_to_percent("Custom Status XYZ")
+        assert result is None
+
+
+class TestJiraWebhookProcessorExtractDescription:
+    """Tests for _extract_description_text method."""
+
+    @pytest.fixture
+    def processor(self):
+        """Create a JiraWebhookProcessor with mocked dependencies."""
+        return JiraWebhookProcessor(
+            integration_repo=AsyncMock(),
+            mapping_repo=AsyncMock(),
+            activity_repo=AsyncMock(),
+            wbs_repo=AsyncMock(),
+            sync_log_repo=AsyncMock(),
+        )
+
+    def test_string_description(self, processor):
+        """Should return string description as-is."""
+        result = processor._extract_description_text("Simple description")
+        assert result == "Simple description"
+
+    def test_adf_description(self, processor):
+        """Should extract text from ADF format."""
+        adf = {
+            "type": "doc",
+            "content": [
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "Hello "}],
+                },
+                {
+                    "type": "paragraph",
+                    "content": [{"type": "text", "text": "World"}],
+                },
+            ],
+        }
+        result = processor._extract_description_text(adf)
+        assert result == "Hello \nWorld"
+
+    def test_empty_adf(self, processor):
+        """Should return None for empty ADF."""
+        adf = {"type": "doc", "content": []}
+        result = processor._extract_description_text(adf)
+        assert result is None
+
+    def test_non_text_content(self, processor):
+        """Should handle ADF with non-text content."""
+        adf = {
+            "type": "doc",
+            "content": [
+                {"type": "rule"},  # Horizontal rule
+            ],
+        }
+        result = processor._extract_description_text(adf)
+        assert result is None
+
+    def test_none_description(self, processor):
+        """Should return None for None description."""
+        result = processor._extract_description_text(None)
+        assert result is None
+
+
+class TestJiraWebhookProcessorProcessWebhook:
+    """Tests for process_webhook method."""
+
+    @pytest.fixture
+    def processor(self):
+        """Create a JiraWebhookProcessor with mocked dependencies."""
+        mock_integration_repo = AsyncMock()
+        mock_mapping_repo = AsyncMock()
+        mock_activity_repo = AsyncMock()
+        mock_wbs_repo = AsyncMock()
+        mock_sync_log_repo = AsyncMock()
+
+        return JiraWebhookProcessor(
+            integration_repo=mock_integration_repo,
+            mapping_repo=mock_mapping_repo,
+            activity_repo=mock_activity_repo,
+            wbs_repo=mock_wbs_repo,
+            sync_log_repo=mock_sync_log_repo,
+        )
+
+    @pytest.mark.asyncio
+    async def test_no_issue_data(self, processor):
+        """Should return failure for payload without issue data."""
+        payload = JiraWebhookPayload(
+            webhookEvent="jira:issue_updated",
+            issue=None,
+        )
+
+        result = await processor.process_webhook(payload)
+
+        assert result.success is False
+        assert "No issue data" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_missing_issue_key(self, processor):
+        """Should return failure for missing issue key."""
+        payload = JiraWebhookPayload(
+            webhookEvent="jira:issue_updated",
+            issue={"fields": {"project": {"key": "PROJ"}}},
+        )
+
+        result = await processor.process_webhook(payload)
+
+        assert result.success is False
+        assert "Missing issue key" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_no_matching_integration(self, processor):
+        """Should ignore webhook when no integration matches."""
+        processor.integration_repo.get_active_integrations.return_value = []
+
+        payload = JiraWebhookPayload(
+            webhookEvent="jira:issue_updated",
+            issue={
+                "key": "PROJ-123",
+                "fields": {"project": {"key": "PROJ"}},
+            },
+        )
+
+        result = await processor.process_webhook(payload)
+
+        assert result.success is True
+        assert result.action_taken == "ignored_no_integration"
+
+    @pytest.mark.asyncio
+    async def test_sync_disabled(self, processor):
+        """Should ignore webhook when sync is disabled."""
+        mock_integration = MagicMock()
+        mock_integration.sync_enabled = False
+        mock_integration.project_key = "PROJ"
+        processor.integration_repo.get_active_integrations.return_value = [mock_integration]
+
+        payload = JiraWebhookPayload(
+            webhookEvent="jira:issue_updated",
+            issue={
+                "key": "PROJ-123",
+                "fields": {"project": {"key": "PROJ"}},
+            },
+        )
+
+        result = await processor.process_webhook(payload)
+
+        assert result.success is True
+        assert result.action_taken == "ignored_sync_disabled"
+
+    @pytest.mark.asyncio
+    async def test_no_mapping_found(self, processor):
+        """Should ignore webhook when no mapping exists."""
+        mock_integration = MagicMock()
+        mock_integration.id = uuid4()
+        mock_integration.sync_enabled = True
+        mock_integration.project_key = "PROJ"
+        processor.integration_repo.get_active_integrations.return_value = [mock_integration]
+        processor.mapping_repo.get_by_jira_key.return_value = None
+
+        payload = JiraWebhookPayload(
+            webhookEvent="jira:issue_updated",
+            issue={
+                "key": "PROJ-123",
+                "fields": {"project": {"key": "PROJ"}},
+            },
+        )
+
+        result = await processor.process_webhook(payload)
+
+        assert result.success is True
+        assert result.action_taken == "ignored_no_mapping"
+
+    @pytest.mark.asyncio
+    async def test_to_jira_only_sync_direction(self, processor):
+        """Should ignore webhook for to_jira only mappings."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.project_key = "PROJ"
+        processor.integration_repo.get_active_integrations.return_value = [mock_integration]
+
+        mock_mapping = MagicMock()
+        mock_mapping.sync_direction = "to_jira"
+        mock_mapping.entity_type = "activity"
+        processor.mapping_repo.get_by_jira_key.return_value = mock_mapping
+
+        payload = JiraWebhookPayload(
+            webhookEvent="jira:issue_updated",
+            issue={
+                "key": "PROJ-123",
+                "fields": {"project": {"key": "PROJ"}},
+            },
+        )
+
+        result = await processor.process_webhook(payload)
+
+        assert result.success is True
+        assert result.action_taken == "ignored_sync_direction"
+
+    @pytest.mark.asyncio
+    async def test_unsupported_event(self, processor):
+        """Should ignore unsupported webhook events."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        mock_integration.id = integration_id
+        mock_integration.sync_enabled = True
+        mock_integration.project_key = "PROJ"
+        processor.integration_repo.get_active_integrations.return_value = [mock_integration]
+
+        mock_mapping = MagicMock()
+        mock_mapping.id = uuid4()
+        mock_mapping.sync_direction = "bidirectional"
+        mock_mapping.entity_type = "activity"
+        processor.mapping_repo.get_by_jira_key.return_value = mock_mapping
+
+        payload = JiraWebhookPayload(
+            webhookEvent="jira:issue_commented",  # Unsupported event
+            issue={
+                "key": "PROJ-123",
+                "fields": {"project": {"key": "PROJ"}},
+            },
+        )
+
+        result = await processor.process_webhook(payload)
+
+        assert result.success is True
+        assert result.action_taken == "ignored_unsupported_event"
+
+
+class TestJiraWebhookProcessorHandleIssueUpdated:
+    """Tests for _handle_issue_updated method."""
+
+    @pytest.fixture
+    def processor(self):
+        """Create a JiraWebhookProcessor with mocked dependencies."""
+        return JiraWebhookProcessor(
+            integration_repo=AsyncMock(),
+            mapping_repo=AsyncMock(),
+            activity_repo=AsyncMock(),
+            wbs_repo=AsyncMock(),
+            sync_log_repo=AsyncMock(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_update_activity_status(self, processor):
+        """Should update activity percent complete from status change."""
+        integration = MagicMock()
+        activity_id = uuid4()
+
+        mapping = MagicMock()
+        mapping.entity_type = "activity"
+        mapping.activity_id = activity_id
+        mapping.wbs_id = None
+
+        activity = MagicMock()
+        activity.name = "Original Name"
+        activity.percent_complete = Decimal("0")
+        processor.activity_repo.get.return_value = activity
+
+        issue = {
+            "key": "PROJ-123",
+            "fields": {
+                "summary": "Original Name",
+                "status": {"name": "Done"},
+            },
+        }
+
+        payload = JiraWebhookPayload(
+            webhookEvent="jira:issue_updated",
+            issue=issue,
+            changelog={"items": [{"field": "status", "fromString": "To Do", "toString": "Done"}]},
+        )
+
+        result = await processor._handle_issue_updated(integration, mapping, issue, payload)
+
+        assert result.success is True
+        assert "progress=100%" in result.action_taken
+        processor.activity_repo.update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_update_activity_name(self, processor):
+        """Should update activity name from summary change."""
+        integration = MagicMock()
+        activity_id = uuid4()
+
+        mapping = MagicMock()
+        mapping.entity_type = "activity"
+        mapping.activity_id = activity_id
+        mapping.wbs_id = None
+
+        activity = MagicMock()
+        activity.name = "Original Name"
+        activity.percent_complete = Decimal("50")
+        processor.activity_repo.get.return_value = activity
+
+        issue = {
+            "key": "PROJ-123",
+            "fields": {
+                "summary": "New Name",
+                "status": {"name": "In Progress"},
+            },
+        }
+
+        payload = JiraWebhookPayload(
+            webhookEvent="jira:issue_updated",
+            issue=issue,
+            changelog=None,
+        )
+
+        result = await processor._handle_issue_updated(integration, mapping, issue, payload)
+
+        assert result.success is True
+        assert "name" in result.action_taken
+        processor.activity_repo.update.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_activity_not_found(self, processor):
+        """Should return failure when activity not found."""
+        integration = MagicMock()
+        activity_id = uuid4()
+
+        mapping = MagicMock()
+        mapping.entity_type = "activity"
+        mapping.activity_id = activity_id
+        mapping.wbs_id = None
+
+        processor.activity_repo.get.return_value = None
+
+        issue = {
+            "key": "PROJ-123",
+            "fields": {"summary": "Test", "status": {"name": "Done"}},
+        }
+
+        payload = JiraWebhookPayload(
+            webhookEvent="jira:issue_updated",
+            issue=issue,
+        )
+
+        result = await processor._handle_issue_updated(integration, mapping, issue, payload)
+
+        assert result.success is False
+        assert "not found" in result.error_message
+
+    @pytest.mark.asyncio
+    async def test_update_wbs_name(self, processor):
+        """Should update WBS name from summary change."""
+        integration = MagicMock()
+        wbs_id = uuid4()
+
+        mapping = MagicMock()
+        mapping.entity_type = "wbs"
+        mapping.wbs_id = wbs_id
+        mapping.activity_id = None
+
+        wbs = MagicMock()
+        wbs.name = "Original WBS Name"
+        wbs.description = None
+        processor.wbs_repo.get.return_value = wbs
+
+        issue = {
+            "key": "PROJ-123",
+            "fields": {
+                "summary": "New WBS Name",
+                "description": None,
+            },
+        }
+
+        payload = JiraWebhookPayload(
+            webhookEvent="jira:issue_updated",
+            issue=issue,
+        )
+
+        result = await processor._handle_issue_updated(integration, mapping, issue, payload)
+
+        assert result.success is True
+        assert "name" in result.action_taken
+        processor.wbs_repo.update.assert_called_once()
+
+
+class TestJiraWebhookProcessorHandleIssueDeleted:
+    """Tests for _handle_issue_deleted method."""
+
+    @pytest.fixture
+    def processor(self):
+        """Create a JiraWebhookProcessor with mocked dependencies."""
+        return JiraWebhookProcessor(
+            integration_repo=AsyncMock(),
+            mapping_repo=AsyncMock(),
+            activity_repo=AsyncMock(),
+            wbs_repo=AsyncMock(),
+            sync_log_repo=AsyncMock(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_soft_deletes_mapping(self, processor):
+        """Should soft-delete the mapping when issue is deleted."""
+        integration = MagicMock()
+        integration.id = uuid4()
+
+        mapping = MagicMock()
+        mapping.id = uuid4()
+        mapping.entity_type = "activity"
+        mapping.activity_id = uuid4()
+        mapping.wbs_id = None
+
+        issue = {"key": "PROJ-123"}
+
+        payload = JiraWebhookPayload(
+            webhookEvent="jira:issue_deleted",
+            issue=issue,
+        )
+
+        result = await processor._handle_issue_deleted(integration, mapping, issue, payload)
+
+        assert result.success is True
+        assert result.action_taken == "mapping_deleted"
+        processor.mapping_repo.delete.assert_called_once_with(mapping.id)
+
+
+class TestJiraWebhookProcessorHandleIssueCreated:
+    """Tests for _handle_issue_created method."""
+
+    @pytest.fixture
+    def processor(self):
+        """Create a JiraWebhookProcessor with mocked dependencies."""
+        return JiraWebhookProcessor(
+            integration_repo=AsyncMock(),
+            mapping_repo=AsyncMock(),
+            activity_repo=AsyncMock(),
+            wbs_repo=AsyncMock(),
+            sync_log_repo=AsyncMock(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_updates_mapping_timestamp(self, processor):
+        """Should update mapping timestamp for created event."""
+        integration = MagicMock()
+        integration.id = uuid4()
+
+        mapping = MagicMock()
+        mapping.entity_type = "activity"
+        mapping.activity_id = uuid4()
+        mapping.wbs_id = None
+
+        issue = {"key": "PROJ-123"}
+
+        payload = JiraWebhookPayload(
+            webhookEvent="jira:issue_created",
+            issue=issue,
+        )
+
+        result = await processor._handle_issue_created(integration, mapping, issue, payload)
+
+        assert result.success is True
+        assert result.action_taken == "mapping_updated"
+        processor.mapping_repo.update.assert_called_once()
+
+
+class TestJiraWebhookProcessorFindIntegration:
+    """Tests for _find_integration method."""
+
+    @pytest.fixture
+    def processor(self):
+        """Create a JiraWebhookProcessor with mocked dependencies."""
+        return JiraWebhookProcessor(
+            integration_repo=AsyncMock(),
+            mapping_repo=AsyncMock(),
+            activity_repo=AsyncMock(),
+            wbs_repo=AsyncMock(),
+            sync_log_repo=AsyncMock(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_find_by_integration_id(self, processor):
+        """Should find integration by direct ID."""
+        integration_id = uuid4()
+        mock_integration = MagicMock()
+        processor.integration_repo.get.return_value = mock_integration
+
+        result = await processor._find_integration(integration_id=integration_id)
+
+        assert result is mock_integration
+        processor.integration_repo.get.assert_called_once_with(integration_id)
+
+    @pytest.mark.asyncio
+    async def test_find_by_project_key(self, processor):
+        """Should find integration by project key."""
+        mock_integration = MagicMock()
+        mock_integration.project_key = "PROJ"
+        processor.integration_repo.get_active_integrations.return_value = [mock_integration]
+
+        result = await processor._find_integration(project_key="PROJ")
+
+        assert result is mock_integration
+
+    @pytest.mark.asyncio
+    async def test_not_found_by_project_key(self, processor):
+        """Should return None when project key doesn't match."""
+        mock_integration = MagicMock()
+        mock_integration.project_key = "OTHER"
+        processor.integration_repo.get_active_integrations.return_value = [mock_integration]
+
+        result = await processor._find_integration(project_key="PROJ")
+
+        assert result is None
+
+    @pytest.mark.asyncio
+    async def test_no_parameters(self, processor):
+        """Should return None when no parameters provided."""
+        result = await processor._find_integration()
+
+        assert result is None
+
+
+class TestJiraWebhookProcessorLogSync:
+    """Tests for _log_sync method."""
+
+    @pytest.fixture
+    def processor(self):
+        """Create a JiraWebhookProcessor with mocked dependencies."""
+        return JiraWebhookProcessor(
+            integration_repo=AsyncMock(),
+            mapping_repo=AsyncMock(),
+            activity_repo=AsyncMock(),
+            wbs_repo=AsyncMock(),
+            sync_log_repo=AsyncMock(),
+        )
+
+    @pytest.mark.asyncio
+    async def test_creates_sync_log_entry(self, processor):
+        """Should create sync log with all parameters."""
+        integration_id = uuid4()
+        mapping_id = uuid4()
+
+        await processor._log_sync(
+            integration_id=integration_id,
+            mapping_id=mapping_id,
+            sync_type="webhook",
+            status="success",
+            items_synced=1,
+            error_message=None,
+            duration_ms=150,
+        )
+
+        processor.sync_log_repo.create.assert_called_once()
+        call_args = processor.sync_log_repo.create.call_args[0][0]
+        assert call_args["integration_id"] == integration_id
+        assert call_args["mapping_id"] == mapping_id
+        assert call_args["sync_type"] == "webhook"
+        assert call_args["status"] == "success"
+        assert call_args["items_synced"] == 1
+        assert call_args["duration_ms"] == 150
+
+    @pytest.mark.asyncio
+    async def test_creates_sync_log_with_error(self, processor):
+        """Should include error message in sync log."""
+        integration_id = uuid4()
+
+        await processor._log_sync(
+            integration_id=integration_id,
+            mapping_id=None,
+            sync_type="webhook",
+            status="failed",
+            items_synced=0,
+            error_message="Processing failed",
+            duration_ms=50,
+        )
+
+        call_args = processor.sync_log_repo.create.call_args[0][0]
+        assert call_args["status"] == "failed"
+        assert call_args["error_message"] == "Processing failed"


### PR DESCRIPTION
## Summary
- Add webhook endpoint to receive Jira events at POST /webhooks/jira
- Add JiraWebhookProcessor service to handle jira:issue_created, jira:issue_updated, jira:issue_deleted events
- Implement status-to-progress mapping, summary and description sync from Jira issues
- Add HMAC-SHA256 signature verification for webhook security
- Include 50 unit tests with comprehensive coverage

## Changes
- `api/src/api/v1/endpoints/jira_webhook.py` - Webhook endpoints
- `api/src/services/jira_webhook_processor.py` - Webhook processing service
- `api/tests/unit/test_jira_webhook.py` - Unit tests
- `api/src/api/v1/router.py` - Register webhook router
- `api/src/services/__init__.py` - Export JiraWebhookProcessor

## Test plan
- [x] All 50 unit tests passing
- [x] Ruff linting passes
- [x] Mypy type checking passes
- [ ] Integration test with Jira sandbox (manual)

🤖 Generated with [Claude Code](https://claude.com/claude-code)