### PR TITLE
Security: Rate Limiting Implementation

### DIFF
--- a/api/src/api/v1/endpoints/jira_webhook.py
+++ b/api/src/api/v1/endpoints/jira_webhook.py
@@ -18,6 +18,7 @@ from fastapi import APIRouter, Header, HTTPException, Request, status
 
 from src.config import settings
 from src.core.deps import DbSession
+from src.core.rate_limit import RATE_LIMIT_WEBHOOK, limiter
 from src.repositories.activity import ActivityRepository
 from src.repositories.jira_integration import JiraIntegrationRepository
 from src.repositories.jira_mapping import JiraMappingRepository
@@ -71,6 +72,7 @@ class WebhookResponse:
         500: {"description": "Internal processing error"},
     },
 )
+@limiter.limit(RATE_LIMIT_WEBHOOK)
 async def receive_jira_webhook(
     request: Request,
     db: DbSession,

--- a/api/src/api/v1/endpoints/reports.py
+++ b/api/src/api/v1/endpoints/reports.py
@@ -6,11 +6,12 @@ from decimal import Decimal
 from typing import Annotated, Any, cast
 from uuid import UUID
 
-from fastapi import APIRouter, Query
+from fastapi import APIRouter, Query, Request
 from fastapi.responses import HTMLResponse, Response
 
 from src.core.deps import CurrentUser, DbSession
 from src.core.exceptions import AuthorizationError, NotFoundError
+from src.core.rate_limit import RATE_LIMIT_REPORTS, limiter
 from src.repositories.baseline import BaselineRepository
 from src.repositories.evms_period import EVMSPeriodRepository
 from src.repositories.management_reserve_log import ManagementReserveLogRepository
@@ -402,7 +403,9 @@ def _format5_to_dict(report: Any) -> dict[str, Any]:
 
 
 @router.get("/cpr/{program_id}/pdf")
+@limiter.limit(RATE_LIMIT_REPORTS)
 async def generate_cpr_format1_pdf(
+    request: Request,
     program_id: UUID,
     db: DbSession,
     period_id: Annotated[UUID | None, Query(description="Specific period ID")] = None,
@@ -486,7 +489,9 @@ async def generate_cpr_format1_pdf(
 
 
 @router.get("/cpr-format3/{program_id}/pdf")
+@limiter.limit(RATE_LIMIT_REPORTS)
 async def generate_cpr_format3_pdf(
+    request: Request,
     program_id: UUID,
     db: DbSession,
     current_user: CurrentUser,
@@ -570,7 +575,9 @@ async def generate_cpr_format3_pdf(
 
 
 @router.get("/cpr-format5/{program_id}/pdf")
+@limiter.limit(RATE_LIMIT_REPORTS)
 async def generate_cpr_format5_pdf(
+    request: Request,
     program_id: UUID,
     db: DbSession,
     current_user: CurrentUser,

--- a/api/src/config.py
+++ b/api/src/config.py
@@ -70,6 +70,9 @@ class Settings(BaseSettings):
     # Logging
     LOG_LEVEL: Literal["DEBUG", "INFO", "WARNING", "ERROR", "CRITICAL"] = "INFO"
 
+    # Rate Limiting
+    RATE_LIMIT_ENABLED: bool = True
+
     @field_validator("CORS_ORIGINS", mode="before")
     @classmethod
     def parse_cors_origins(cls, v: str | list[str]) -> list[str]:

--- a/api/src/core/rate_limit.py
+++ b/api/src/core/rate_limit.py
@@ -1,0 +1,96 @@
+"""Rate limiting configuration using slowapi.
+
+Provides rate limiting middleware and decorators for API endpoints.
+Different limits for different endpoint categories:
+- Default: 100/minute
+- Auth: 10/minute (prevent brute force)
+- Reports: 5/minute (resource intensive)
+- Sync: 20/minute (external API calls)
+"""
+
+from __future__ import annotations
+
+import os
+from typing import TYPE_CHECKING
+
+from slowapi import Limiter
+from slowapi.util import get_remote_address
+from starlette.responses import JSONResponse
+
+if TYPE_CHECKING:
+    from starlette.requests import Request
+
+# Check if rate limiting is enabled (can be disabled for testing)
+RATE_LIMIT_ENABLED = os.environ.get("RATE_LIMIT_ENABLED", "true").lower() == "true"
+
+
+def get_client_ip(request: Request) -> str:
+    """
+    Get client IP address for rate limiting.
+
+    Handles X-Forwarded-For header for proxied requests.
+
+    Args:
+        request: The incoming request
+
+    Returns:
+        Client IP address string
+    """
+    # Check for forwarded header (behind proxy/load balancer)
+    forwarded = request.headers.get("X-Forwarded-For")
+    if forwarded:
+        # Take first IP in chain (original client)
+        return forwarded.split(",")[0].strip()
+
+    # Fall back to direct client
+    return get_remote_address(request)
+
+
+# Create limiter instance
+# When RATE_LIMIT_ENABLED=false, the limiter is disabled and passes all requests
+limiter = Limiter(
+    key_func=get_client_ip,
+    default_limits=["100/minute"],
+    storage_uri="memory://",  # Use Redis in production: "redis://localhost:6379"
+    enabled=RATE_LIMIT_ENABLED,
+)
+
+
+# Rate limit categories
+RATE_LIMIT_DEFAULT = "100/minute"
+RATE_LIMIT_AUTH = "10/minute"
+RATE_LIMIT_REPORTS = "5/minute"
+RATE_LIMIT_SYNC = "20/minute"
+RATE_LIMIT_WEBHOOK = "60/minute"
+
+
+def rate_limit_exceeded_handler(_request: Request, exc: Exception) -> JSONResponse:
+    """
+    Custom handler for rate limit exceeded errors.
+
+    Returns a JSON response with rate limit information and
+    appropriate headers for client retry logic.
+
+    Args:
+        request: The incoming request
+        exc: The rate limit exceeded exception
+
+    Returns:
+        JSONResponse with 429 status and retry information
+    """
+    retry_after = getattr(exc, "retry_after", 60)
+    detail = getattr(exc, "detail", None)
+    limit_detail = str(detail) if detail else "100/minute"
+
+    return JSONResponse(
+        status_code=429,
+        content={
+            "error": "rate_limit_exceeded",
+            "message": f"Rate limit exceeded: {limit_detail}",
+            "retry_after": retry_after,
+        },
+        headers={
+            "Retry-After": str(retry_after),
+            "X-RateLimit-Limit": limit_detail,
+        },
+    )

--- a/api/tests/conftest.py
+++ b/api/tests/conftest.py
@@ -9,6 +9,9 @@ from decimal import Decimal
 from pathlib import Path
 from uuid import uuid4
 
+# Disable rate limiting for tests - must be set before importing app
+os.environ["RATE_LIMIT_ENABLED"] = "false"
+
 import pytest
 import pytest_asyncio
 from httpx import ASGITransport, AsyncClient

--- a/api/tests/unit/test_rate_limit.py
+++ b/api/tests/unit/test_rate_limit.py
@@ -1,0 +1,247 @@
+"""Tests for rate limiting functionality."""
+
+from __future__ import annotations
+
+from unittest.mock import MagicMock, patch
+
+from slowapi.errors import RateLimitExceeded
+from starlette.requests import Request
+
+from src.core.rate_limit import (
+    RATE_LIMIT_AUTH,
+    RATE_LIMIT_DEFAULT,
+    RATE_LIMIT_REPORTS,
+    RATE_LIMIT_SYNC,
+    RATE_LIMIT_WEBHOOK,
+    get_client_ip,
+    rate_limit_exceeded_handler,
+)
+
+# =============================================================================
+# Test: get_client_ip
+# =============================================================================
+
+
+class TestGetClientIp:
+    """Tests for client IP extraction."""
+
+    def test_uses_forwarded_header_single_ip(self):
+        """Should use X-Forwarded-For when present with single IP."""
+        request = MagicMock(spec=Request)
+        request.headers = {"X-Forwarded-For": "1.2.3.4"}
+
+        result = get_client_ip(request)
+        assert result == "1.2.3.4"
+
+    def test_uses_forwarded_header_multiple_ips(self):
+        """Should use first IP from X-Forwarded-For when multiple present."""
+        request = MagicMock(spec=Request)
+        request.headers = {"X-Forwarded-For": "1.2.3.4, 5.6.7.8, 9.10.11.12"}
+
+        result = get_client_ip(request)
+        assert result == "1.2.3.4"
+
+    def test_strips_whitespace_from_forwarded_ip(self):
+        """Should strip whitespace from forwarded IP."""
+        request = MagicMock(spec=Request)
+        request.headers = {"X-Forwarded-For": "  1.2.3.4  , 5.6.7.8"}
+
+        result = get_client_ip(request)
+        assert result == "1.2.3.4"
+
+    def test_falls_back_to_remote_address(self):
+        """Should fall back to remote address when no forwarded header."""
+        request = MagicMock(spec=Request)
+        request.headers = {}
+
+        with patch("src.core.rate_limit.get_remote_address") as mock_get:
+            mock_get.return_value = "10.0.0.1"
+            result = get_client_ip(request)
+            assert result == "10.0.0.1"
+            mock_get.assert_called_once_with(request)
+
+    def test_handles_empty_forwarded_header(self):
+        """Should fall back when forwarded header is empty."""
+        request = MagicMock(spec=Request)
+        request.headers = {"X-Forwarded-For": ""}
+
+        with patch("src.core.rate_limit.get_remote_address") as mock_get:
+            mock_get.return_value = "10.0.0.1"
+            result = get_client_ip(request)
+            assert result == "10.0.0.1"
+
+
+# =============================================================================
+# Test: rate_limit_exceeded_handler
+# =============================================================================
+
+
+class TestRateLimitExceededHandler:
+    """Tests for rate limit exceeded response."""
+
+    def test_returns_429_status(self):
+        """Should return 429 status code."""
+        request = MagicMock(spec=Request)
+        exc = MagicMock(spec=RateLimitExceeded)
+        exc.detail = "100/minute"
+        exc.retry_after = 60
+
+        response = rate_limit_exceeded_handler(request, exc)
+
+        assert response.status_code == 429
+
+    def test_includes_retry_after_header(self):
+        """Should include Retry-After header."""
+        request = MagicMock(spec=Request)
+        exc = MagicMock(spec=RateLimitExceeded)
+        exc.detail = "100/minute"
+        exc.retry_after = 30
+
+        response = rate_limit_exceeded_handler(request, exc)
+
+        assert response.headers.get("Retry-After") == "30"
+
+    def test_includes_rate_limit_header(self):
+        """Should include X-RateLimit-Limit header."""
+        request = MagicMock(spec=Request)
+        exc = MagicMock(spec=RateLimitExceeded)
+        exc.detail = "10/minute"
+        exc.retry_after = 60
+
+        response = rate_limit_exceeded_handler(request, exc)
+
+        assert response.headers.get("X-RateLimit-Limit") == "10/minute"
+
+    def test_response_body_contains_error_info(self):
+        """Should include error information in response body."""
+        request = MagicMock(spec=Request)
+        exc = MagicMock(spec=RateLimitExceeded)
+        exc.detail = "5/minute"
+        exc.retry_after = 45
+
+        response = rate_limit_exceeded_handler(request, exc)
+
+        # Decode response body
+        import json
+
+        body = json.loads(response.body.decode())
+
+        assert body["error"] == "rate_limit_exceeded"
+        assert "5/minute" in body["message"]
+        assert body["retry_after"] == 45
+
+    def test_handles_missing_retry_after(self):
+        """Should default retry_after to 60 if not present."""
+        request = MagicMock(spec=Request)
+        exc = MagicMock(spec=RateLimitExceeded)
+        exc.detail = "100/minute"
+        # Simulate missing retry_after attribute
+        del exc.retry_after
+
+        response = rate_limit_exceeded_handler(request, exc)
+
+        assert response.headers.get("Retry-After") == "60"
+
+    def test_handles_none_detail(self):
+        """Should default to 100/minute if detail is None."""
+        request = MagicMock(spec=Request)
+        exc = MagicMock(spec=RateLimitExceeded)
+        exc.detail = None
+        exc.retry_after = 60
+
+        response = rate_limit_exceeded_handler(request, exc)
+
+        assert response.headers.get("X-RateLimit-Limit") == "100/minute"
+
+
+# =============================================================================
+# Test: Rate Limit Constants
+# =============================================================================
+
+
+class TestRateLimitConstants:
+    """Tests for rate limit constants."""
+
+    def test_default_limit(self):
+        """Default limit should be 100/minute."""
+        assert RATE_LIMIT_DEFAULT == "100/minute"
+
+    def test_auth_limit_stricter_than_default(self):
+        """Auth limit should be stricter than default."""
+        assert RATE_LIMIT_AUTH == "10/minute"
+        # Parse and compare
+        auth_rate = int(RATE_LIMIT_AUTH.split("/")[0])
+        default_rate = int(RATE_LIMIT_DEFAULT.split("/")[0])
+        assert auth_rate < default_rate
+
+    def test_reports_limit_is_strictest(self):
+        """Reports limit should be strictest for resource protection."""
+        assert RATE_LIMIT_REPORTS == "5/minute"
+        # Parse and compare
+        reports_rate = int(RATE_LIMIT_REPORTS.split("/")[0])
+        auth_rate = int(RATE_LIMIT_AUTH.split("/")[0])
+        assert reports_rate < auth_rate
+
+    def test_sync_limit_for_external_api(self):
+        """Sync limit should be moderate for external API calls."""
+        assert RATE_LIMIT_SYNC == "20/minute"
+
+    def test_webhook_limit_higher_for_events(self):
+        """Webhook limit should be higher to handle bursts."""
+        assert RATE_LIMIT_WEBHOOK == "60/minute"
+        # Parse and compare
+        webhook_rate = int(RATE_LIMIT_WEBHOOK.split("/")[0])
+        sync_rate = int(RATE_LIMIT_SYNC.split("/")[0])
+        assert webhook_rate > sync_rate
+
+    def test_all_limits_use_minute_unit(self):
+        """All limits should use per-minute rate."""
+        limits = [
+            RATE_LIMIT_DEFAULT,
+            RATE_LIMIT_AUTH,
+            RATE_LIMIT_REPORTS,
+            RATE_LIMIT_SYNC,
+            RATE_LIMIT_WEBHOOK,
+        ]
+        for limit in limits:
+            assert limit.endswith("/minute"), f"{limit} should end with /minute"
+
+    def test_all_limits_are_positive(self):
+        """All limits should have positive rate values."""
+        limits = [
+            RATE_LIMIT_DEFAULT,
+            RATE_LIMIT_AUTH,
+            RATE_LIMIT_REPORTS,
+            RATE_LIMIT_SYNC,
+            RATE_LIMIT_WEBHOOK,
+        ]
+        for limit in limits:
+            rate = int(limit.split("/")[0])
+            assert rate > 0, f"{limit} should have positive rate"
+
+
+# =============================================================================
+# Test: Limiter Instance
+# =============================================================================
+
+
+class TestLimiterInstance:
+    """Tests for limiter instance configuration."""
+
+    def test_limiter_exists(self):
+        """Limiter instance should be importable."""
+        from src.core.rate_limit import limiter
+
+        assert limiter is not None
+
+    def test_limiter_has_default_limits(self):
+        """Limiter should have default limits configured."""
+        from src.core.rate_limit import limiter
+
+        assert limiter._default_limits is not None
+
+    def test_limiter_uses_custom_key_func(self):
+        """Limiter should use custom key function."""
+        from src.core.rate_limit import limiter
+
+        assert limiter._key_func is not None


### PR DESCRIPTION
## Summary
- Implement rate limiting for API endpoints using slowapi
- Add custom IP extraction with X-Forwarded-For support for proxy environments
- Configure different rate limits per endpoint category for targeted protection

## Rate Limits by Category
| Endpoint Category | Rate Limit | Purpose |
|-------------------|------------|---------|
| Default | 100/minute | General API protection |
| Auth (login/register) | 10/minute | Brute force prevention |
| Reports (PDF) | 5/minute | Resource protection |
| Jira Sync | 20/minute | External API rate limiting |
| Webhooks | 60/minute | Handle burst events |

## Changes
- **api/src/core/rate_limit.py**: Rate limiter configuration
  - `get_client_ip()` - Custom IP extraction with proxy support
  - `rate_limit_exceeded_handler()` - Custom 429 response with Retry-After
  - Rate limit constants for each category
  - `RATE_LIMIT_ENABLED` env var for testing

- **api/src/main.py**: Add limiter to app (conditionally based on setting)

- **api/src/config.py**: Add `RATE_LIMIT_ENABLED` setting

- **Endpoint updates**:
  - `auth.py`: Rate limit login/register/refresh endpoints
  - `reports.py`: Rate limit PDF generation endpoints
  - `jira_integration.py`: Rate limit sync operations
  - `jira_webhook.py`: Rate limit webhook endpoint

- **api/tests/conftest.py**: Disable rate limiting for integration tests

- **api/tests/unit/test_rate_limit.py**: 21 comprehensive unit tests

## Test plan
- [x] All 21 rate limit unit tests pass
- [x] All 2080 unit tests pass
- [x] All 165 integration tests pass
- [x] ruff lint and format pass
- [x] mypy type checking passes

## Security Notes
- Rate limiting prevents DoS attacks, brute force attacks, and API abuse
- Custom 429 response includes Retry-After header for client retry logic
- Can be disabled via RATE_LIMIT_ENABLED=false for testing environments

🤖 Generated with [Claude Code](https://claude.com/claude-code)