### PR TITLE
feat(schemas): Resource, ResourceAssignment, and ResourceCalendar schemas

### DIFF
--- a/api/src/models/enums.py
+++ b/api/src/models/enums.py
@@ -594,3 +594,46 @@ class ActivityStatus(str, Enum):
             return cls.IN_PROGRESS
         else:
             return cls.NOT_STARTED
+
+
+class ResourceType(str, Enum):
+    """
+    Resource type classification.
+
+    Resources are categorized by their nature for proper handling
+    of allocation, leveling, and cost calculations.
+
+    Types:
+        LABOR: Human resources (engineers, managers, technicians)
+        EQUIPMENT: Machinery and tools with limited availability
+        MATERIAL: Consumable supplies and components
+
+    Cost Implications:
+        - LABOR: Time-based cost (hours * rate)
+        - EQUIPMENT: Time-based or usage-based cost
+        - MATERIAL: Unit-based cost (quantity * unit price)
+
+    Leveling Behavior:
+        - LABOR: Can be overallocated (overtime) within limits
+        - EQUIPMENT: Strict capacity constraints
+        - MATERIAL: No leveling (consumed, not time-bound)
+    """
+
+    LABOR = "labor"
+    EQUIPMENT = "equipment"
+    MATERIAL = "material"
+
+    @property
+    def display_name(self) -> str:
+        """Get human-readable display name."""
+        return self.value.title()
+
+    @property
+    def is_time_based(self) -> bool:
+        """Check if resource is allocated by time."""
+        return self in (ResourceType.LABOR, ResourceType.EQUIPMENT)
+
+    @property
+    def supports_leveling(self) -> bool:
+        """Check if resource type supports leveling."""
+        return self in (ResourceType.LABOR, ResourceType.EQUIPMENT)

--- a/api/src/schemas/__init__.py
+++ b/api/src/schemas/__init__.py
@@ -82,6 +82,24 @@ from src.schemas.jira_integration import (
     SyncType,
 )
 
+# Resource schemas
+from src.schemas.resource import (
+    ResourceAssignmentCreate,
+    ResourceAssignmentListResponse,
+    ResourceAssignmentResponse,
+    ResourceAssignmentUpdate,
+    ResourceCalendarBase,
+    ResourceCalendarBulkCreate,
+    ResourceCalendarCreate,
+    ResourceCalendarRangeResponse,
+    ResourceCalendarResponse,
+    ResourceCreate,
+    ResourceListResponse,
+    ResourceResponse,
+    ResourceSummary,
+    ResourceUpdate,
+)
+
 # Program schemas
 from src.schemas.program import (
     ProgramBriefResponse,
@@ -198,4 +216,19 @@ __all__ = [
     "SyncResultItem",
     "SyncStatus",
     "SyncType",
+    # Resource
+    "ResourceAssignmentCreate",
+    "ResourceAssignmentListResponse",
+    "ResourceAssignmentResponse",
+    "ResourceAssignmentUpdate",
+    "ResourceCalendarBase",
+    "ResourceCalendarBulkCreate",
+    "ResourceCalendarCreate",
+    "ResourceCalendarRangeResponse",
+    "ResourceCalendarResponse",
+    "ResourceCreate",
+    "ResourceListResponse",
+    "ResourceResponse",
+    "ResourceSummary",
+    "ResourceUpdate",
 ]

--- a/api/src/schemas/resource.py
+++ b/api/src/schemas/resource.py
@@ -1,0 +1,304 @@
+"""Pydantic schemas for Resource, ResourceAssignment, and ResourceCalendar.
+
+Provides validation and serialization for resource management:
+- Resource: Labor, Equipment, Material with capacity and cost rates
+- ResourceAssignment: Activity to resource allocation
+- ResourceCalendar: Per-resource availability by date
+"""
+
+from __future__ import annotations
+
+import re
+from datetime import date  # noqa: TC003 - Required at runtime for Pydantic
+from decimal import Decimal
+from typing import Annotated
+from uuid import UUID  # noqa: TC003 - Required at runtime for Pydantic
+
+from pydantic import BaseModel, ConfigDict, Field, field_validator, model_validator
+
+from src.models.enums import ResourceType
+
+# =============================================================================
+# Resource Schemas
+# =============================================================================
+
+
+class ResourceBase(BaseModel):
+    """Base schema for resource with validation."""
+
+    name: Annotated[str, Field(min_length=1, max_length=100, description="Resource name")]
+    code: Annotated[
+        str,
+        Field(
+            min_length=1,
+            max_length=50,
+            pattern=r"^[A-Z0-9\-_]+$",
+            description="Unique code (uppercase alphanumeric, hyphens, underscores)",
+        ),
+    ]
+    resource_type: ResourceType = Field(
+        default=ResourceType.LABOR,
+        description="Resource classification",
+    )
+    capacity_per_day: Annotated[
+        Decimal,
+        Field(
+            default=Decimal("8.0"),
+            ge=Decimal("0"),
+            le=Decimal("24"),
+            description="Available hours per day (0-24)",
+        ),
+    ]
+    cost_rate: Annotated[
+        Decimal | None,
+        Field(default=None, ge=Decimal("0"), description="Hourly cost rate"),
+    ] = None
+    effective_date: date | None = Field(
+        default=None,
+        description="Date when resource becomes available",
+    )
+    is_active: bool = Field(default=True, description="Whether resource is active")
+
+    @field_validator("code", mode="before")
+    @classmethod
+    def uppercase_code(cls, v: str) -> str:
+        """Convert code to uppercase."""
+        if isinstance(v, str):
+            return v.upper()
+        return v
+
+    @field_validator("code", mode="after")
+    @classmethod
+    def validate_code_pattern(cls, v: str) -> str:
+        """Validate code matches required pattern."""
+        if not re.match(r"^[A-Z0-9\-_]+$", v):
+            msg = "Code must contain only uppercase letters, numbers, hyphens, and underscores"
+            raise ValueError(msg)
+        return v
+
+
+class ResourceCreate(ResourceBase):
+    """Schema for creating a new resource."""
+
+    program_id: UUID = Field(description="Program this resource belongs to")
+
+
+class ResourceUpdate(BaseModel):
+    """Schema for updating a resource. All fields optional."""
+
+    name: Annotated[str | None, Field(min_length=1, max_length=100)] = None
+    code: Annotated[str | None, Field(min_length=1, max_length=50)] = None
+    resource_type: ResourceType | None = None
+    capacity_per_day: Annotated[
+        Decimal | None, Field(ge=Decimal("0"), le=Decimal("24"))
+    ] = None
+    cost_rate: Annotated[Decimal | None, Field(ge=Decimal("0"))] = None
+    effective_date: date | None = None
+    is_active: bool | None = None
+
+    @field_validator("code", mode="before")
+    @classmethod
+    def uppercase_code(cls, v: str | None) -> str | None:
+        """Convert code to uppercase if provided."""
+        if isinstance(v, str):
+            return v.upper()
+        return v
+
+    @field_validator("code", mode="after")
+    @classmethod
+    def validate_code_pattern(cls, v: str | None) -> str | None:
+        """Validate code matches required pattern if provided."""
+        if v is not None and not re.match(r"^[A-Z0-9\-_]+$", v):
+            msg = "Code must contain only uppercase letters, numbers, hyphens, and underscores"
+            raise ValueError(msg)
+        return v
+
+
+class ResourceResponse(ResourceBase):
+    """Schema for resource response."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    program_id: UUID
+    created_at: date
+    updated_at: date | None = None
+
+
+class ResourceListResponse(BaseModel):
+    """Paginated list of resources."""
+
+    items: list[ResourceResponse]
+    total: int = Field(ge=0, description="Total number of resources")
+    page: int = Field(ge=1, description="Current page number")
+    page_size: int = Field(ge=1, le=100, description="Items per page")
+    pages: int = Field(ge=0, description="Total number of pages")
+
+
+class ResourceSummary(BaseModel):
+    """Lightweight resource summary for embedding."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    code: str
+    name: str
+    resource_type: ResourceType
+
+
+# =============================================================================
+# Resource Assignment Schemas
+# =============================================================================
+
+
+class ResourceAssignmentBase(BaseModel):
+    """Base schema for resource assignment."""
+
+    units: Annotated[
+        Decimal,
+        Field(
+            default=Decimal("1.0"),
+            ge=Decimal("0"),
+            le=Decimal("10"),
+            description="Allocation units (0-10, where 1.0 = 100%)",
+        ),
+    ]
+    start_date: date | None = Field(
+        default=None,
+        description="Assignment start date (defaults to activity start)",
+    )
+    finish_date: date | None = Field(
+        default=None,
+        description="Assignment finish date (defaults to activity finish)",
+    )
+
+    @model_validator(mode="after")
+    def validate_dates(self) -> ResourceAssignmentBase:
+        """Validate finish_date >= start_date."""
+        if self.start_date and self.finish_date and self.finish_date < self.start_date:
+            msg = "finish_date must be greater than or equal to start_date"
+            raise ValueError(msg)
+        return self
+
+
+class ResourceAssignmentCreate(ResourceAssignmentBase):
+    """Schema for creating a resource assignment."""
+
+    activity_id: UUID = Field(description="Activity to assign resource to")
+    resource_id: UUID = Field(description="Resource to assign")
+
+
+class ResourceAssignmentUpdate(BaseModel):
+    """Schema for updating a resource assignment."""
+
+    units: Annotated[Decimal | None, Field(ge=Decimal("0"), le=Decimal("10"))] = None
+    start_date: date | None = None
+    finish_date: date | None = None
+
+    @model_validator(mode="after")
+    def validate_dates(self) -> ResourceAssignmentUpdate:
+        """Validate finish_date >= start_date if both provided."""
+        if self.start_date and self.finish_date and self.finish_date < self.start_date:
+            msg = "finish_date must be greater than or equal to start_date"
+            raise ValueError(msg)
+        return self
+
+
+class ResourceAssignmentResponse(ResourceAssignmentBase):
+    """Schema for resource assignment response."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    activity_id: UUID
+    resource_id: UUID
+    resource: ResourceSummary | None = None
+
+
+class ResourceAssignmentListResponse(BaseModel):
+    """List of resource assignments."""
+
+    items: list[ResourceAssignmentResponse]
+    total: int = Field(ge=0)
+
+
+# =============================================================================
+# Resource Calendar Schemas
+# =============================================================================
+
+
+class ResourceCalendarBase(BaseModel):
+    """Base schema for resource calendar entry."""
+
+    calendar_date: date = Field(description="Calendar date")
+    available_hours: Annotated[
+        Decimal,
+        Field(
+            default=Decimal("8.0"),
+            ge=Decimal("0"),
+            le=Decimal("24"),
+            description="Available hours on this date (0-24)",
+        ),
+    ]
+    is_working_day: bool = Field(
+        default=True,
+        description="Whether this is a working day",
+    )
+
+
+class ResourceCalendarCreate(ResourceCalendarBase):
+    """Schema for creating a calendar entry."""
+
+    resource_id: UUID = Field(description="Resource this calendar entry belongs to")
+
+
+class ResourceCalendarEntry(BaseModel):
+    """Single calendar entry for bulk operations."""
+
+    calendar_date: date
+    available_hours: Annotated[
+        Decimal, Field(default=Decimal("8.0"), ge=Decimal("0"), le=Decimal("24"))
+    ]
+    is_working_day: bool = True
+
+
+class ResourceCalendarBulkCreate(BaseModel):
+    """Schema for bulk creating calendar entries."""
+
+    resource_id: UUID = Field(description="Resource to create calendar entries for")
+    entries: Annotated[
+        list[ResourceCalendarEntry],
+        Field(min_length=1, max_length=366, description="Calendar entries (max 366)"),
+    ]
+
+    @field_validator("entries")
+    @classmethod
+    def validate_unique_dates(
+        cls, v: list[ResourceCalendarEntry]
+    ) -> list[ResourceCalendarEntry]:
+        """Ensure no duplicate dates in entries."""
+        dates = [entry.calendar_date for entry in v]
+        if len(dates) != len(set(dates)):
+            msg = "Duplicate dates are not allowed in calendar entries"
+            raise ValueError(msg)
+        return v
+
+
+class ResourceCalendarResponse(ResourceCalendarBase):
+    """Schema for calendar entry response."""
+
+    model_config = ConfigDict(from_attributes=True)
+
+    id: UUID
+    resource_id: UUID
+
+
+class ResourceCalendarRangeResponse(BaseModel):
+    """Schema for calendar range query response."""
+
+    resource_id: UUID
+    start_date: date
+    end_date: date
+    entries: list[ResourceCalendarResponse]
+    working_days: int = Field(ge=0, description="Total working days in range")
+    total_hours: Decimal = Field(ge=Decimal("0"), description="Total available hours")

--- a/api/tests/unit/test_resource_schemas.py
+++ b/api/tests/unit/test_resource_schemas.py
@@ -1,0 +1,379 @@
+"""Unit tests for Resource, ResourceAssignment, and ResourceCalendar schemas."""
+
+from __future__ import annotations
+
+from datetime import date
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+from pydantic import ValidationError
+
+from src.models.enums import ResourceType
+from src.schemas.resource import (
+    ResourceAssignmentBase,
+    ResourceAssignmentCreate,
+    ResourceAssignmentUpdate,
+    ResourceBase,
+    ResourceCalendarBase,
+    ResourceCalendarBulkCreate,
+    ResourceCalendarEntry,
+    ResourceCreate,
+    ResourceUpdate,
+)
+
+# =============================================================================
+# Resource Schema Tests
+# =============================================================================
+
+
+class TestResourceBase:
+    """Tests for ResourceBase schema."""
+
+    def test_valid_resource(self) -> None:
+        """Test creating a valid resource."""
+        resource = ResourceBase(
+            name="Senior Engineer",
+            code="ENG-001",
+            resource_type=ResourceType.LABOR,
+            capacity_per_day=Decimal("8.0"),
+            cost_rate=Decimal("150.00"),
+        )
+        assert resource.name == "Senior Engineer"
+        assert resource.code == "ENG-001"
+        assert resource.resource_type == ResourceType.LABOR
+        assert resource.capacity_per_day == Decimal("8.0")
+        assert resource.cost_rate == Decimal("150.00")
+
+    def test_code_auto_uppercase(self) -> None:
+        """Test that code is automatically uppercased."""
+        resource = ResourceBase(name="Test Resource", code="eng-001")
+        assert resource.code == "ENG-001"
+
+    def test_code_with_numbers_and_underscores(self) -> None:
+        """Test code with numbers and underscores."""
+        resource = ResourceBase(name="Test", code="res_123_a")
+        assert resource.code == "RES_123_A"
+
+    def test_invalid_code_characters(self) -> None:
+        """Test that invalid code characters are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ResourceBase(name="Test", code="eng 001")  # space not allowed
+        assert "string_pattern_mismatch" in str(exc_info.value)
+
+    def test_invalid_code_special_chars(self) -> None:
+        """Test that special characters in code are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ResourceBase(name="Test", code="eng@001")
+        assert "string_pattern_mismatch" in str(exc_info.value)
+
+    def test_capacity_range_valid(self) -> None:
+        """Test valid capacity values within range."""
+        resource = ResourceBase(name="Test", code="T1", capacity_per_day=Decimal("0"))
+        assert resource.capacity_per_day == Decimal("0")
+
+        resource = ResourceBase(name="Test", code="T1", capacity_per_day=Decimal("24"))
+        assert resource.capacity_per_day == Decimal("24")
+
+    def test_capacity_below_minimum(self) -> None:
+        """Test that capacity below 0 is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ResourceBase(name="Test", code="T1", capacity_per_day=Decimal("-1"))
+        assert "greater than or equal to 0" in str(exc_info.value)
+
+    def test_capacity_above_maximum(self) -> None:
+        """Test that capacity above 24 is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ResourceBase(name="Test", code="T1", capacity_per_day=Decimal("25"))
+        assert "less than or equal to 24" in str(exc_info.value)
+
+    def test_cost_rate_negative_rejected(self) -> None:
+        """Test that negative cost rate is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ResourceBase(name="Test", code="T1", cost_rate=Decimal("-10"))
+        assert "greater than or equal to 0" in str(exc_info.value)
+
+    def test_name_too_long(self) -> None:
+        """Test that name exceeding 100 chars is rejected."""
+        with pytest.raises(ValidationError):
+            ResourceBase(name="x" * 101, code="T1")
+
+    def test_code_too_long(self) -> None:
+        """Test that code exceeding 50 chars is rejected."""
+        with pytest.raises(ValidationError):
+            ResourceBase(name="Test", code="X" * 51)
+
+    def test_default_values(self) -> None:
+        """Test that defaults are properly set."""
+        resource = ResourceBase(name="Test", code="T1")
+        assert resource.resource_type == ResourceType.LABOR
+        assert resource.capacity_per_day == Decimal("8.0")
+        assert resource.cost_rate is None
+        assert resource.effective_date is None
+        assert resource.is_active is True
+
+
+class TestResourceCreate:
+    """Tests for ResourceCreate schema."""
+
+    def test_create_with_program_id(self) -> None:
+        """Test creating resource with program ID."""
+        program_id = uuid4()
+        resource = ResourceCreate(
+            name="Engineer",
+            code="ENG-001",
+            program_id=program_id,
+        )
+        assert resource.program_id == program_id
+
+
+class TestResourceUpdate:
+    """Tests for ResourceUpdate schema."""
+
+    def test_partial_update(self) -> None:
+        """Test partial update with only some fields."""
+        update = ResourceUpdate(name="New Name")
+        assert update.name == "New Name"
+        assert update.code is None
+        assert update.resource_type is None
+
+    def test_update_code_uppercase(self) -> None:
+        """Test that code is uppercased in update."""
+        update = ResourceUpdate(code="new-code")
+        assert update.code == "NEW-CODE"
+
+    def test_update_invalid_code(self) -> None:
+        """Test that invalid code in update is rejected."""
+        with pytest.raises(ValidationError):
+            ResourceUpdate(code="invalid code")
+
+
+# =============================================================================
+# Resource Assignment Schema Tests
+# =============================================================================
+
+
+class TestResourceAssignmentBase:
+    """Tests for ResourceAssignmentBase schema."""
+
+    def test_valid_assignment(self) -> None:
+        """Test creating a valid assignment."""
+        assignment = ResourceAssignmentBase(
+            units=Decimal("1.0"),
+            start_date=date(2024, 1, 1),
+            finish_date=date(2024, 1, 31),
+        )
+        assert assignment.units == Decimal("1.0")
+        assert assignment.start_date == date(2024, 1, 1)
+        assert assignment.finish_date == date(2024, 1, 31)
+
+    def test_units_range_valid(self) -> None:
+        """Test valid units values within range."""
+        assignment = ResourceAssignmentBase(units=Decimal("0"))
+        assert assignment.units == Decimal("0")
+
+        assignment = ResourceAssignmentBase(units=Decimal("10"))
+        assert assignment.units == Decimal("10")
+
+    def test_units_below_minimum(self) -> None:
+        """Test that units below 0 is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ResourceAssignmentBase(units=Decimal("-0.1"))
+        assert "greater than or equal to 0" in str(exc_info.value)
+
+    def test_units_above_maximum(self) -> None:
+        """Test that units above 10 is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ResourceAssignmentBase(units=Decimal("10.1"))
+        assert "less than or equal to 10" in str(exc_info.value)
+
+    def test_date_validation_valid(self) -> None:
+        """Test that valid date range is accepted."""
+        assignment = ResourceAssignmentBase(
+            start_date=date(2024, 1, 1),
+            finish_date=date(2024, 1, 1),  # same day is valid
+        )
+        assert assignment.start_date == assignment.finish_date
+
+    def test_date_validation_invalid(self) -> None:
+        """Test that finish_date < start_date is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ResourceAssignmentBase(
+                start_date=date(2024, 1, 31),
+                finish_date=date(2024, 1, 1),
+            )
+        assert "finish_date must be greater than or equal to start_date" in str(
+            exc_info.value
+        )
+
+    def test_dates_optional(self) -> None:
+        """Test that dates can be omitted."""
+        assignment = ResourceAssignmentBase()
+        assert assignment.start_date is None
+        assert assignment.finish_date is None
+
+
+class TestResourceAssignmentCreate:
+    """Tests for ResourceAssignmentCreate schema."""
+
+    def test_create_assignment(self) -> None:
+        """Test creating an assignment with IDs."""
+        activity_id = uuid4()
+        resource_id = uuid4()
+        assignment = ResourceAssignmentCreate(
+            activity_id=activity_id,
+            resource_id=resource_id,
+            units=Decimal("0.5"),
+        )
+        assert assignment.activity_id == activity_id
+        assert assignment.resource_id == resource_id
+        assert assignment.units == Decimal("0.5")
+
+
+class TestResourceAssignmentUpdate:
+    """Tests for ResourceAssignmentUpdate schema."""
+
+    def test_partial_update(self) -> None:
+        """Test partial update of assignment."""
+        update = ResourceAssignmentUpdate(units=Decimal("2.0"))
+        assert update.units == Decimal("2.0")
+        assert update.start_date is None
+
+    def test_update_date_validation(self) -> None:
+        """Test date validation in update."""
+        with pytest.raises(ValidationError):
+            ResourceAssignmentUpdate(
+                start_date=date(2024, 12, 31),
+                finish_date=date(2024, 1, 1),
+            )
+
+
+# =============================================================================
+# Resource Calendar Schema Tests
+# =============================================================================
+
+
+class TestResourceCalendarBase:
+    """Tests for ResourceCalendarBase schema."""
+
+    def test_valid_calendar_entry(self) -> None:
+        """Test creating a valid calendar entry."""
+        entry = ResourceCalendarBase(
+            calendar_date=date(2024, 1, 15),
+            available_hours=Decimal("8.0"),
+            is_working_day=True,
+        )
+        assert entry.calendar_date == date(2024, 1, 15)
+        assert entry.available_hours == Decimal("8.0")
+        assert entry.is_working_day is True
+
+    def test_hours_range_valid(self) -> None:
+        """Test valid hours values within range."""
+        entry = ResourceCalendarBase(calendar_date=date(2024, 1, 1), available_hours=Decimal("0"))
+        assert entry.available_hours == Decimal("0")
+
+        entry = ResourceCalendarBase(
+            calendar_date=date(2024, 1, 1), available_hours=Decimal("24")
+        )
+        assert entry.available_hours == Decimal("24")
+
+    def test_hours_below_minimum(self) -> None:
+        """Test that hours below 0 is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ResourceCalendarBase(calendar_date=date(2024, 1, 1), available_hours=Decimal("-1"))
+        assert "greater than or equal to 0" in str(exc_info.value)
+
+    def test_hours_above_maximum(self) -> None:
+        """Test that hours above 24 is rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ResourceCalendarBase(calendar_date=date(2024, 1, 1), available_hours=Decimal("25"))
+        assert "less than or equal to 24" in str(exc_info.value)
+
+    def test_non_working_day(self) -> None:
+        """Test non-working day entry."""
+        entry = ResourceCalendarBase(
+            calendar_date=date(2024, 1, 1),
+            available_hours=Decimal("0"),
+            is_working_day=False,
+        )
+        assert entry.is_working_day is False
+
+
+class TestResourceCalendarBulkCreate:
+    """Tests for ResourceCalendarBulkCreate schema."""
+
+    def test_valid_bulk_create(self) -> None:
+        """Test creating multiple calendar entries."""
+        resource_id = uuid4()
+        bulk = ResourceCalendarBulkCreate(
+            resource_id=resource_id,
+            entries=[
+                ResourceCalendarEntry(calendar_date=date(2024, 1, 1)),
+                ResourceCalendarEntry(calendar_date=date(2024, 1, 2)),
+                ResourceCalendarEntry(calendar_date=date(2024, 1, 3)),
+            ],
+        )
+        assert bulk.resource_id == resource_id
+        assert len(bulk.entries) == 3
+
+    def test_bulk_create_max_limit(self) -> None:
+        """Test that bulk create is limited to 366 entries."""
+        with pytest.raises(ValidationError) as exc_info:
+            ResourceCalendarBulkCreate(
+                resource_id=uuid4(),
+                entries=[
+                    ResourceCalendarEntry(calendar_date=date(2024, 1, 1) + __import__('datetime').timedelta(days=i))
+                    for i in range(367)
+                ],
+            )
+        assert "at most 366" in str(exc_info.value).lower()
+
+    def test_bulk_create_empty_rejected(self) -> None:
+        """Test that empty entries list is rejected."""
+        with pytest.raises(ValidationError):
+            ResourceCalendarBulkCreate(resource_id=uuid4(), entries=[])
+
+    def test_duplicate_dates_rejected(self) -> None:
+        """Test that duplicate dates in bulk create are rejected."""
+        with pytest.raises(ValidationError) as exc_info:
+            ResourceCalendarBulkCreate(
+                resource_id=uuid4(),
+                entries=[
+                    ResourceCalendarEntry(calendar_date=date(2024, 1, 1)),
+                    ResourceCalendarEntry(calendar_date=date(2024, 1, 1)),  # duplicate
+                ],
+            )
+        assert "Duplicate dates" in str(exc_info.value)
+
+
+# =============================================================================
+# Resource Type Enum Tests
+# =============================================================================
+
+
+class TestResourceType:
+    """Tests for ResourceType enum."""
+
+    def test_labor_type(self) -> None:
+        """Test LABOR resource type."""
+        assert ResourceType.LABOR.value == "labor"
+        assert ResourceType.LABOR.is_time_based is True
+        assert ResourceType.LABOR.supports_leveling is True
+
+    def test_equipment_type(self) -> None:
+        """Test EQUIPMENT resource type."""
+        assert ResourceType.EQUIPMENT.value == "equipment"
+        assert ResourceType.EQUIPMENT.is_time_based is True
+        assert ResourceType.EQUIPMENT.supports_leveling is True
+
+    def test_material_type(self) -> None:
+        """Test MATERIAL resource type."""
+        assert ResourceType.MATERIAL.value == "material"
+        assert ResourceType.MATERIAL.is_time_based is False
+        assert ResourceType.MATERIAL.supports_leveling is False
+
+    def test_display_name(self) -> None:
+        """Test display name formatting."""
+        assert ResourceType.LABOR.display_name == "Labor"
+        assert ResourceType.EQUIPMENT.display_name == "Equipment"
+        assert ResourceType.MATERIAL.display_name == "Material"


### PR DESCRIPTION
## Summary
- Add ResourceType enum (LABOR, EQUIPMENT, MATERIAL) with `is_time_based` and `supports_leveling` properties
- Create comprehensive Pydantic v2 schemas for Resource, ResourceAssignment, and ResourceCalendar entities
- Add field validators for code auto-uppercase and pattern validation
- Add model validators for date range validation in assignments
- Add bulk create validator for unique calendar dates

## Week 14 Resource Foundation Progress
This PR implements the first deliverable of Week 14: Pydantic schemas for resource management.

### Schemas Created
| Schema | Purpose |
|--------|---------|
| ResourceBase | Base validation with name, code, type, capacity |
| ResourceCreate | Creation with program_id |
| ResourceUpdate | Partial updates |
| ResourceResponse | API response with timestamps |
| ResourceListResponse | Paginated list response |
| ResourceSummary | Lightweight embedding |
| ResourceAssignmentBase | Assignment with units, dates |
| ResourceAssignmentCreate | Assignment with activity/resource IDs |
| ResourceAssignmentUpdate | Partial assignment updates |
| ResourceAssignmentResponse | Assignment with nested resource |
| ResourceCalendarBase | Calendar entry with hours, working day |
| ResourceCalendarCreate | Single entry creation |
| ResourceCalendarBulkCreate | Bulk creation (max 366 entries) |
| ResourceCalendarResponse | Calendar response |
| ResourceCalendarRangeResponse | Range query with totals |

### Validation Rules
- Code: uppercase alphanumeric, hyphens, underscores (auto-uppercased)
- Capacity: 0-24 hours per day
- Units: 0-10 (where 1.0 = 100%)
- Date validation: finish_date >= start_date
- Bulk calendar: unique dates, max 366 entries

## Test plan
- [x] 39 unit tests covering all schema validations
- [x] All 2212 unit tests pass
- [x] Ruff linting passes
- [x] mypy type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)