### PR TITLE
feat(repository): Resource, Assignment, Calendar repositories

### DIFF
--- a/api/src/models/__init__.py
+++ b/api/src/models/__init__.py
@@ -42,6 +42,9 @@ from src.models.management_reserve_log import ManagementReserveLog
 from src.models.program import Program
 from src.models.report_audit import ReportAudit
 
+# Week 14: Resource models
+from src.models.resource import Resource, ResourceAssignment, ResourceCalendar
+
 # Import models
 from src.models.user import User
 from src.models.variance_explanation import VarianceExplanation
@@ -70,6 +73,10 @@ __all__ = [
     "Program",
     "ProgramStatus",
     "ReportAudit",
+    # Week 14: Resource models
+    "Resource",
+    "ResourceAssignment",
+    "ResourceCalendar",
     "SoftDeleteMixin",
     "SyncDirection",
     "SyncStatus",

--- a/api/src/models/activity.py
+++ b/api/src/models/activity.py
@@ -30,6 +30,7 @@ if TYPE_CHECKING:
     from src.models.dependency import Dependency
     from src.models.jira_mapping import JiraMapping
     from src.models.program import Program
+    from src.models.resource import ResourceAssignment
     from src.models.wbs import WBSElement
 
 
@@ -285,6 +286,13 @@ class Activity(Base):
         "JiraMapping",
         back_populates="activity",
         uselist=False,
+        cascade="all, delete-orphan",
+    )
+
+    # Week 14: Resource assignments
+    resource_assignments: Mapped[list["ResourceAssignment"]] = relationship(
+        "ResourceAssignment",
+        back_populates="activity",
         cascade="all, delete-orphan",
     )
 

--- a/api/src/models/program.py
+++ b/api/src/models/program.py
@@ -18,6 +18,7 @@ if TYPE_CHECKING:
     from src.models.jira_integration import JiraIntegration
     from src.models.management_reserve_log import ManagementReserveLog
     from src.models.report_audit import ReportAudit
+    from src.models.resource import Resource
     from src.models.user import User
     from src.models.variance_explanation import VarianceExplanation
     from src.models.wbs import WBSElement
@@ -170,6 +171,15 @@ class Program(Base):
         back_populates="program",
         uselist=False,
         cascade="all, delete-orphan",
+    )
+
+    # Week 14: Resources
+    resources: Mapped[list["Resource"]] = relationship(
+        "Resource",
+        back_populates="program",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+        order_by="Resource.code",
     )
 
     # Table-level configuration

--- a/api/src/models/resource.py
+++ b/api/src/models/resource.py
@@ -1,0 +1,357 @@
+"""Resource models for resource management with capacity and calendar support."""
+
+from datetime import date
+from decimal import Decimal
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import (
+    Boolean,
+    CheckConstraint,
+    Date,
+    ForeignKey,
+    Index,
+    Numeric,
+    String,
+    UniqueConstraint,
+    text,
+)
+from sqlalchemy.dialects.postgresql import ENUM as PgEnum
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base
+from src.models.enums import ResourceType
+
+if TYPE_CHECKING:
+    from src.models.activity import Activity
+    from src.models.program import Program
+
+
+class Resource(Base):
+    """
+    Represents a resource that can be assigned to activities.
+
+    Resources can be of type LABOR, EQUIPMENT, or MATERIAL.
+    Labor and Equipment resources are time-based and support leveling.
+    Material resources are quantity-based.
+
+    Attributes:
+        program_id: FK to parent program
+        name: Resource name/description
+        code: Unique resource code within program
+        resource_type: Classification (LABOR, EQUIPMENT, MATERIAL)
+        capacity_per_day: Available hours per day (0-24)
+        cost_rate: Hourly cost rate
+        effective_date: Date when resource becomes available
+        is_active: Whether resource is currently active
+    """
+
+    __tablename__ = "resources"
+
+    # Foreign key to Program
+    program_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("programs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="FK to parent program",
+    )
+
+    # Resource identification
+    name: Mapped[str] = mapped_column(
+        String(100),
+        nullable=False,
+        index=True,
+        comment="Resource name/description",
+    )
+
+    code: Mapped[str] = mapped_column(
+        String(50),
+        nullable=False,
+        index=True,
+        comment="Unique resource code within program",
+    )
+
+    # Resource type
+    resource_type: Mapped[ResourceType] = mapped_column(
+        PgEnum(ResourceType, name="resource_type", create_type=True),
+        default=ResourceType.LABOR,
+        nullable=False,
+        index=True,
+        comment="Resource classification (LABOR, EQUIPMENT, MATERIAL)",
+    )
+
+    # Capacity and cost
+    capacity_per_day: Mapped[Decimal] = mapped_column(
+        Numeric(precision=5, scale=2),
+        nullable=False,
+        default=Decimal("8.00"),
+        comment="Available hours per day (0-24)",
+    )
+
+    cost_rate: Mapped[Decimal | None] = mapped_column(
+        Numeric(precision=15, scale=2),
+        nullable=True,
+        comment="Hourly cost rate",
+    )
+
+    # Availability
+    effective_date: Mapped[date | None] = mapped_column(
+        Date,
+        nullable=True,
+        index=True,
+        comment="Date when resource becomes available",
+    )
+
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        default=True,
+        nullable=False,
+        index=True,
+        comment="Whether resource is currently active",
+    )
+
+    # Relationships
+    program: Mapped["Program"] = relationship(
+        "Program",
+        back_populates="resources",
+    )
+
+    assignments: Mapped[list["ResourceAssignment"]] = relationship(
+        "ResourceAssignment",
+        back_populates="resource",
+        cascade="all, delete-orphan",
+    )
+
+    calendar_entries: Mapped[list["ResourceCalendar"]] = relationship(
+        "ResourceCalendar",
+        back_populates="resource",
+        cascade="all, delete-orphan",
+    )
+
+    # Table-level configuration
+    __table_args__ = (
+        # Unique constraint: resource code must be unique within a program
+        UniqueConstraint(
+            "program_id",
+            "code",
+            name="uq_resources_program_code",
+        ),
+        # Check constraint for capacity range
+        CheckConstraint(
+            "capacity_per_day >= 0 AND capacity_per_day <= 24",
+            name="ck_resources_capacity",
+        ),
+        # Check constraint for non-negative cost rate
+        CheckConstraint(
+            "cost_rate IS NULL OR cost_rate >= 0",
+            name="ck_resources_cost_rate",
+        ),
+        # Index for active resources by type
+        Index(
+            "ix_resources_active_type",
+            "program_id",
+            "resource_type",
+            "is_active",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        {"comment": "Resources for assignment to activities"},
+    )
+
+    def __repr__(self) -> str:
+        """Return string representation for debugging."""
+        return (
+            f"<Resource(id={self.id}, code={self.code!r}, name={self.name!r}, "
+            f"type={self.resource_type.value}, capacity={self.capacity_per_day})>"
+        )
+
+
+class ResourceAssignment(Base):
+    """
+    Represents an assignment of a resource to an activity.
+
+    Assignments specify how much of a resource is allocated to an activity
+    and for what period. Units represent allocation percentage where
+    1.0 = 100% allocation.
+
+    Attributes:
+        activity_id: FK to assigned activity
+        resource_id: FK to assigned resource
+        units: Allocation units (0-10, where 1.0 = 100%)
+        start_date: Assignment start date (defaults to activity start)
+        finish_date: Assignment finish date (defaults to activity finish)
+    """
+
+    __tablename__ = "resource_assignments"
+
+    # Foreign keys
+    activity_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("activities.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="FK to assigned activity",
+    )
+
+    resource_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("resources.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="FK to assigned resource",
+    )
+
+    # Allocation
+    units: Mapped[Decimal] = mapped_column(
+        Numeric(precision=5, scale=2),
+        nullable=False,
+        default=Decimal("1.00"),
+        comment="Allocation units (0-10, where 1.0 = 100%)",
+    )
+
+    # Date range
+    start_date: Mapped[date | None] = mapped_column(
+        Date,
+        nullable=True,
+        index=True,
+        comment="Assignment start date (defaults to activity start)",
+    )
+
+    finish_date: Mapped[date | None] = mapped_column(
+        Date,
+        nullable=True,
+        index=True,
+        comment="Assignment finish date (defaults to activity finish)",
+    )
+
+    # Relationships
+    activity: Mapped["Activity"] = relationship(
+        "Activity",
+        back_populates="resource_assignments",
+    )
+
+    resource: Mapped["Resource"] = relationship(
+        "Resource",
+        back_populates="assignments",
+    )
+
+    # Table-level configuration
+    __table_args__ = (
+        # Unique constraint: one assignment per activity-resource pair
+        UniqueConstraint(
+            "activity_id",
+            "resource_id",
+            name="uq_resource_assignments_activity_resource",
+        ),
+        # Check constraint for units range
+        CheckConstraint(
+            "units >= 0 AND units <= 10",
+            name="ck_resource_assignments_units",
+        ),
+        # Check constraint for valid date range
+        CheckConstraint(
+            "start_date IS NULL OR finish_date IS NULL OR finish_date >= start_date",
+            name="ck_resource_assignments_dates",
+        ),
+        # Index for resource utilization queries
+        Index(
+            "ix_resource_assignments_resource_dates",
+            "resource_id",
+            "start_date",
+            "finish_date",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        {"comment": "Resource assignments to activities"},
+    )
+
+    def __repr__(self) -> str:
+        """Return string representation for debugging."""
+        return (
+            f"<ResourceAssignment(id={self.id}, activity_id={self.activity_id}, "
+            f"resource_id={self.resource_id}, units={self.units})>"
+        )
+
+
+class ResourceCalendar(Base):
+    """
+    Represents a calendar entry for a resource on a specific date.
+
+    Calendar entries define resource availability on specific dates,
+    allowing for holidays, vacations, and variable work hours.
+
+    Attributes:
+        resource_id: FK to resource
+        calendar_date: Calendar date
+        available_hours: Available hours on this date (0-24)
+        is_working_day: Whether this is a working day
+    """
+
+    __tablename__ = "resource_calendars"
+
+    # Foreign key to Resource
+    resource_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("resources.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="FK to resource",
+    )
+
+    # Calendar data
+    calendar_date: Mapped[date] = mapped_column(
+        Date,
+        nullable=False,
+        index=True,
+        comment="Calendar date",
+    )
+
+    available_hours: Mapped[Decimal] = mapped_column(
+        Numeric(precision=5, scale=2),
+        nullable=False,
+        default=Decimal("8.00"),
+        comment="Available hours on this date (0-24)",
+    )
+
+    is_working_day: Mapped[bool] = mapped_column(
+        Boolean,
+        default=True,
+        nullable=False,
+        comment="Whether this is a working day",
+    )
+
+    # Relationships
+    resource: Mapped["Resource"] = relationship(
+        "Resource",
+        back_populates="calendar_entries",
+    )
+
+    # Table-level configuration
+    __table_args__ = (
+        # Unique constraint: one entry per resource-date pair
+        UniqueConstraint(
+            "resource_id",
+            "calendar_date",
+            name="uq_resource_calendars_resource_date",
+        ),
+        # Check constraint for hours range
+        CheckConstraint(
+            "available_hours >= 0 AND available_hours <= 24",
+            name="ck_resource_calendars_hours",
+        ),
+        # Index for date range queries
+        Index(
+            "ix_resource_calendars_date_range",
+            "resource_id",
+            "calendar_date",
+            postgresql_where=text("deleted_at IS NULL"),
+        ),
+        {"comment": "Resource calendar entries for availability"},
+    )
+
+    def __repr__(self) -> str:
+        """Return string representation for debugging."""
+        return (
+            f"<ResourceCalendar(id={self.id}, resource_id={self.resource_id}, "
+            f"date={self.calendar_date}, hours={self.available_hours})>"
+        )

--- a/api/src/repositories/__init__.py
+++ b/api/src/repositories/__init__.py
@@ -7,6 +7,11 @@ from src.repositories.jira_integration import JiraIntegrationRepository
 from src.repositories.jira_mapping import JiraMappingRepository
 from src.repositories.jira_sync_log import JiraSyncLogRepository
 from src.repositories.program import ProgramRepository
+from src.repositories.resource import (
+    ResourceAssignmentRepository,
+    ResourceCalendarRepository,
+    ResourceRepository,
+)
 from src.repositories.wbs import WBSElementRepository
 
 __all__ = [
@@ -18,5 +23,8 @@ __all__ = [
     "JiraMappingRepository",
     "JiraSyncLogRepository",
     "ProgramRepository",
+    "ResourceAssignmentRepository",
+    "ResourceCalendarRepository",
+    "ResourceRepository",
     "WBSElementRepository",
 ]

--- a/api/src/repositories/resource.py
+++ b/api/src/repositories/resource.py
@@ -1,0 +1,491 @@
+"""Repository layer for Resource, ResourceAssignment, and ResourceCalendar."""
+
+from datetime import date
+from decimal import Decimal
+from typing import Any
+from uuid import UUID
+
+from sqlalchemy import delete, func, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import joinedload
+
+from src.models.enums import ResourceType
+from src.models.resource import Resource, ResourceAssignment, ResourceCalendar
+from src.repositories.base import BaseRepository
+
+
+class ResourceRepository(BaseRepository[Resource]):
+    """
+    Repository for Resource model operations.
+
+    Provides program-scoped resource queries, code lookups, and
+    eager loading of assignments.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize repository with Resource model."""
+        super().__init__(Resource, session)
+
+    async def get_by_program(
+        self,
+        program_id: UUID,
+        *,
+        resource_type: ResourceType | None = None,
+        is_active: bool | None = None,
+        skip: int = 0,
+        limit: int = 50,
+    ) -> tuple[list[Resource], int]:
+        """
+        Get resources for a program with optional filters.
+
+        Args:
+            program_id: Program UUID
+            resource_type: Filter by resource type
+            is_active: Filter by active status
+            skip: Number of records to skip
+            limit: Maximum number of records to return
+
+        Returns:
+            Tuple of (list of resources, total count)
+        """
+        # Build base query
+        query = select(Resource).where(Resource.program_id == program_id)
+        query = self._apply_soft_delete_filter(query)
+
+        # Apply optional filters
+        if resource_type is not None:
+            query = query.where(Resource.resource_type == resource_type)
+        if is_active is not None:
+            query = query.where(Resource.is_active == is_active)
+
+        # Get total count
+        count_query = select(func.count()).select_from(query.subquery())
+        count_result = await self.session.execute(count_query)
+        total = count_result.scalar_one()
+
+        # Apply pagination and ordering
+        query = query.order_by(Resource.code).offset(skip).limit(limit)
+
+        result = await self.session.execute(query)
+        items = list(result.scalars().all())
+
+        return items, total
+
+    async def count_by_program(
+        self,
+        program_id: UUID,
+        *,
+        resource_type: ResourceType | None = None,
+        is_active: bool | None = None,
+    ) -> int:
+        """
+        Count resources for a program with optional filters.
+
+        Args:
+            program_id: Program UUID
+            resource_type: Filter by resource type
+            is_active: Filter by active status
+
+        Returns:
+            Number of matching resources
+        """
+        query = select(func.count()).select_from(Resource).where(Resource.program_id == program_id)
+        query = self._apply_soft_delete_filter(query)
+
+        if resource_type is not None:
+            query = query.where(Resource.resource_type == resource_type)
+        if is_active is not None:
+            query = query.where(Resource.is_active == is_active)
+
+        result = await self.session.execute(query)
+        count: int = result.scalar_one()
+        return count
+
+    async def get_by_code(
+        self,
+        program_id: UUID,
+        code: str,
+    ) -> Resource | None:
+        """
+        Get a resource by its code within a program.
+
+        Args:
+            program_id: Program UUID
+            code: Resource code (case-insensitive)
+
+        Returns:
+            Resource if found, None otherwise
+        """
+        query = (
+            select(Resource)
+            .where(Resource.program_id == program_id)
+            .where(func.upper(Resource.code) == code.upper())
+        )
+        query = self._apply_soft_delete_filter(query)
+
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()
+
+    async def code_exists(
+        self,
+        program_id: UUID,
+        code: str,
+        *,
+        exclude_id: UUID | None = None,
+    ) -> bool:
+        """
+        Check if a resource code exists within a program.
+
+        Args:
+            program_id: Program UUID
+            code: Resource code to check
+            exclude_id: Optional resource ID to exclude from check
+
+        Returns:
+            True if code exists, False otherwise
+        """
+        query = (
+            select(func.count())
+            .select_from(Resource)
+            .where(Resource.program_id == program_id)
+            .where(func.upper(Resource.code) == code.upper())
+        )
+        query = self._apply_soft_delete_filter(query)
+
+        if exclude_id is not None:
+            query = query.where(Resource.id != exclude_id)
+
+        result = await self.session.execute(query)
+        count: int = result.scalar_one()
+        return count > 0
+
+    async def get_with_assignments(
+        self,
+        resource_id: UUID,
+    ) -> Resource | None:
+        """
+        Get a resource with its assignments eagerly loaded.
+
+        Args:
+            resource_id: Resource UUID
+
+        Returns:
+            Resource with assignments if found, None otherwise
+        """
+        query = (
+            select(Resource)
+            .where(Resource.id == resource_id)
+            .options(joinedload(Resource.assignments))
+        )
+        query = self._apply_soft_delete_filter(query)
+
+        result = await self.session.execute(query)
+        return result.unique().scalar_one_or_none()
+
+
+class ResourceAssignmentRepository(BaseRepository[ResourceAssignment]):
+    """
+    Repository for ResourceAssignment model operations.
+
+    Provides activity and resource scoped queries with eager loading.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize repository with ResourceAssignment model."""
+        super().__init__(ResourceAssignment, session)
+
+    async def get_by_activity(
+        self,
+        activity_id: UUID,
+    ) -> list[ResourceAssignment]:
+        """
+        Get all assignments for an activity with resource eagerly loaded.
+
+        Args:
+            activity_id: Activity UUID
+
+        Returns:
+            List of assignments with resources
+        """
+        query = (
+            select(ResourceAssignment)
+            .where(ResourceAssignment.activity_id == activity_id)
+            .options(joinedload(ResourceAssignment.resource))
+        )
+        query = self._apply_soft_delete_filter(query)
+
+        result = await self.session.execute(query)
+        return list(result.unique().scalars().all())
+
+    async def get_by_resource(
+        self,
+        resource_id: UUID,
+        *,
+        start_date: date | None = None,
+        end_date: date | None = None,
+    ) -> list[ResourceAssignment]:
+        """
+        Get all assignments for a resource with optional date filtering.
+
+        Args:
+            resource_id: Resource UUID
+            start_date: Optional start date filter
+            end_date: Optional end date filter
+
+        Returns:
+            List of assignments
+        """
+        query = select(ResourceAssignment).where(ResourceAssignment.resource_id == resource_id)
+        query = self._apply_soft_delete_filter(query)
+
+        # Filter by date range if provided
+        if start_date is not None:
+            query = query.where(
+                (ResourceAssignment.finish_date.is_(None))
+                | (ResourceAssignment.finish_date >= start_date)
+            )
+        if end_date is not None:
+            query = query.where(
+                (ResourceAssignment.start_date.is_(None))
+                | (ResourceAssignment.start_date <= end_date)
+            )
+
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def assignment_exists(
+        self,
+        activity_id: UUID,
+        resource_id: UUID,
+        *,
+        exclude_id: UUID | None = None,
+    ) -> bool:
+        """
+        Check if an assignment exists for an activity-resource pair.
+
+        Args:
+            activity_id: Activity UUID
+            resource_id: Resource UUID
+            exclude_id: Optional assignment ID to exclude
+
+        Returns:
+            True if assignment exists, False otherwise
+        """
+        query = (
+            select(func.count())
+            .select_from(ResourceAssignment)
+            .where(ResourceAssignment.activity_id == activity_id)
+            .where(ResourceAssignment.resource_id == resource_id)
+        )
+        query = self._apply_soft_delete_filter(query)
+
+        if exclude_id is not None:
+            query = query.where(ResourceAssignment.id != exclude_id)
+
+        result = await self.session.execute(query)
+        count: int = result.scalar_one()
+        return count > 0
+
+    async def get_total_units_for_resource(
+        self,
+        resource_id: UUID,
+        on_date: date,
+    ) -> Decimal:
+        """
+        Get total allocation units for a resource on a specific date.
+
+        Args:
+            resource_id: Resource UUID
+            on_date: Date to check allocation
+
+        Returns:
+            Total units allocated on the date
+        """
+        query = (
+            select(func.coalesce(func.sum(ResourceAssignment.units), Decimal("0")))
+            .where(ResourceAssignment.resource_id == resource_id)
+            .where(
+                (ResourceAssignment.start_date.is_(None))
+                | (ResourceAssignment.start_date <= on_date)
+            )
+            .where(
+                (ResourceAssignment.finish_date.is_(None))
+                | (ResourceAssignment.finish_date >= on_date)
+            )
+        )
+        query = self._apply_soft_delete_filter(query)
+
+        result = await self.session.execute(query)
+        total: Decimal = result.scalar_one()
+        return total
+
+
+class ResourceCalendarRepository(BaseRepository[ResourceCalendar]):
+    """
+    Repository for ResourceCalendar model operations.
+
+    Provides date range queries, bulk operations, and aggregations.
+    """
+
+    def __init__(self, session: AsyncSession) -> None:
+        """Initialize repository with ResourceCalendar model."""
+        super().__init__(ResourceCalendar, session)
+
+    async def get_for_date_range(
+        self,
+        resource_id: UUID,
+        start_date: date,
+        end_date: date,
+    ) -> list[ResourceCalendar]:
+        """
+        Get calendar entries for a resource within a date range.
+
+        Args:
+            resource_id: Resource UUID
+            start_date: Range start date (inclusive)
+            end_date: Range end date (inclusive)
+
+        Returns:
+            List of calendar entries ordered by date
+        """
+        query = (
+            select(ResourceCalendar)
+            .where(ResourceCalendar.resource_id == resource_id)
+            .where(ResourceCalendar.calendar_date >= start_date)
+            .where(ResourceCalendar.calendar_date <= end_date)
+            .order_by(ResourceCalendar.calendar_date)
+        )
+        query = self._apply_soft_delete_filter(query)
+
+        result = await self.session.execute(query)
+        return list(result.scalars().all())
+
+    async def get_by_date(
+        self,
+        resource_id: UUID,
+        calendar_date: date,
+    ) -> ResourceCalendar | None:
+        """
+        Get a calendar entry for a specific date.
+
+        Args:
+            resource_id: Resource UUID
+            calendar_date: The date to look up
+
+        Returns:
+            Calendar entry if found, None otherwise
+        """
+        query = (
+            select(ResourceCalendar)
+            .where(ResourceCalendar.resource_id == resource_id)
+            .where(ResourceCalendar.calendar_date == calendar_date)
+        )
+        query = self._apply_soft_delete_filter(query)
+
+        result = await self.session.execute(query)
+        return result.scalar_one_or_none()
+
+    async def bulk_create_entries(
+        self,
+        entries: list[dict[str, Any]],
+    ) -> list[ResourceCalendar]:
+        """
+        Create multiple calendar entries efficiently.
+
+        Args:
+            entries: List of entry dictionaries
+
+        Returns:
+            List of created calendar entries
+        """
+        return await self.bulk_create(entries)
+
+    async def get_working_days_count(
+        self,
+        resource_id: UUID,
+        start_date: date,
+        end_date: date,
+    ) -> int:
+        """
+        Count working days for a resource within a date range.
+
+        Args:
+            resource_id: Resource UUID
+            start_date: Range start date (inclusive)
+            end_date: Range end date (inclusive)
+
+        Returns:
+            Number of working days
+        """
+        query = (
+            select(func.count())
+            .select_from(ResourceCalendar)
+            .where(ResourceCalendar.resource_id == resource_id)
+            .where(ResourceCalendar.calendar_date >= start_date)
+            .where(ResourceCalendar.calendar_date <= end_date)
+            .where(ResourceCalendar.is_working_day.is_(True))
+        )
+        query = self._apply_soft_delete_filter(query)
+
+        result = await self.session.execute(query)
+        count: int = result.scalar_one()
+        return count
+
+    async def get_total_hours(
+        self,
+        resource_id: UUID,
+        start_date: date,
+        end_date: date,
+    ) -> Decimal:
+        """
+        Get total available hours for a resource within a date range.
+
+        Args:
+            resource_id: Resource UUID
+            start_date: Range start date (inclusive)
+            end_date: Range end date (inclusive)
+
+        Returns:
+            Total available hours
+        """
+        query = (
+            select(func.coalesce(func.sum(ResourceCalendar.available_hours), Decimal("0")))
+            .where(ResourceCalendar.resource_id == resource_id)
+            .where(ResourceCalendar.calendar_date >= start_date)
+            .where(ResourceCalendar.calendar_date <= end_date)
+        )
+        query = self._apply_soft_delete_filter(query)
+
+        result = await self.session.execute(query)
+        total: Decimal = result.scalar_one()
+        return total
+
+    async def delete_range(
+        self,
+        resource_id: UUID,
+        start_date: date,
+        end_date: date,
+    ) -> int:
+        """
+        Delete calendar entries for a resource within a date range.
+
+        Args:
+            resource_id: Resource UUID
+            start_date: Range start date (inclusive)
+            end_date: Range end date (inclusive)
+
+        Returns:
+            Number of entries deleted
+        """
+        # Use hard delete for calendar entries (no soft delete needed)
+        stmt = (
+            delete(ResourceCalendar)
+            .where(ResourceCalendar.resource_id == resource_id)
+            .where(ResourceCalendar.calendar_date >= start_date)
+            .where(ResourceCalendar.calendar_date <= end_date)
+        )
+
+        cursor_result = await self.session.execute(stmt)
+        await self.session.flush()
+        deleted: int = cursor_result.rowcount  # type: ignore[attr-defined]
+        return deleted

--- a/api/tests/integration/test_resource_repository.py
+++ b/api/tests/integration/test_resource_repository.py
@@ -1,0 +1,647 @@
+"""Integration tests for Resource, ResourceAssignment, and ResourceCalendar repositories."""
+
+from datetime import date, timedelta
+from decimal import Decimal
+from uuid import uuid4
+
+import pytest
+import pytest_asyncio
+from sqlalchemy.ext.asyncio import AsyncSession
+
+from src.models.activity import Activity
+from src.models.enums import ResourceType
+from src.models.program import Program
+from src.models.resource import Resource, ResourceAssignment
+from src.models.user import User
+from src.models.wbs import WBSElement
+from src.repositories.resource import (
+    ResourceAssignmentRepository,
+    ResourceCalendarRepository,
+    ResourceRepository,
+)
+
+pytestmark = pytest.mark.asyncio
+
+
+# =============================================================================
+# Fixtures
+# =============================================================================
+
+
+@pytest_asyncio.fixture
+async def test_user(db_session: AsyncSession) -> User:
+    """Create a test user."""
+    user = User(
+        id=uuid4(),
+        email=f"test_{uuid4().hex[:8]}@example.com",
+        hashed_password="hashed",
+        full_name="Test User",
+    )
+    db_session.add(user)
+    await db_session.flush()
+    return user
+
+
+@pytest_asyncio.fixture
+async def test_program(db_session: AsyncSession, test_user: User) -> Program:
+    """Create a test program."""
+    program = Program(
+        id=uuid4(),
+        code=f"PRG-{uuid4().hex[:6]}",
+        name="Test Program",
+        start_date=date(2024, 1, 1),
+        end_date=date(2024, 12, 31),
+        owner_id=test_user.id,
+    )
+    db_session.add(program)
+    await db_session.flush()
+    return program
+
+
+@pytest_asyncio.fixture
+async def test_wbs(db_session: AsyncSession, test_program: Program) -> WBSElement:
+    """Create a test WBS element."""
+    wbs = WBSElement(
+        id=uuid4(),
+        program_id=test_program.id,
+        wbs_code="1.1",
+        name="Work Package 1",
+        path="1.1",  # ltree path required
+        level=1,
+    )
+    db_session.add(wbs)
+    await db_session.flush()
+    return wbs
+
+
+@pytest_asyncio.fixture
+async def test_activity(
+    db_session: AsyncSession, test_program: Program, test_wbs: WBSElement
+) -> Activity:
+    """Create a test activity."""
+    activity = Activity(
+        id=uuid4(),
+        program_id=test_program.id,
+        wbs_id=test_wbs.id,
+        code="ACT-001",
+        name="Test Activity",
+        duration=10,
+    )
+    db_session.add(activity)
+    await db_session.flush()
+    return activity
+
+
+@pytest_asyncio.fixture
+async def test_resource(db_session: AsyncSession, test_program: Program) -> Resource:
+    """Create a test resource."""
+    resource = Resource(
+        id=uuid4(),
+        program_id=test_program.id,
+        code="ENG-001",
+        name="Senior Engineer",
+        resource_type=ResourceType.LABOR,
+        capacity_per_day=Decimal("8.0"),
+        cost_rate=Decimal("150.00"),
+        is_active=True,
+    )
+    db_session.add(resource)
+    await db_session.flush()
+    return resource
+
+
+# =============================================================================
+# ResourceRepository Tests
+# =============================================================================
+
+
+class TestResourceRepository:
+    """Tests for ResourceRepository."""
+
+    async def test_create_resource(self, db_session: AsyncSession, test_program: Program) -> None:
+        """Test creating a resource."""
+        repo = ResourceRepository(db_session)
+
+        resource = await repo.create(
+            {
+                "program_id": test_program.id,
+                "code": "DEV-001",
+                "name": "Developer",
+                "resource_type": ResourceType.LABOR,
+                "capacity_per_day": Decimal("8.0"),
+            }
+        )
+
+        assert resource.id is not None
+        assert resource.code == "DEV-001"
+        assert resource.name == "Developer"
+        assert resource.resource_type == ResourceType.LABOR
+
+    async def test_get_by_program(
+        self, db_session: AsyncSession, test_program: Program, test_resource: Resource
+    ) -> None:
+        """Test getting resources by program."""
+        repo = ResourceRepository(db_session)
+
+        # Create another resource
+        await repo.create(
+            {
+                "program_id": test_program.id,
+                "code": "EQP-001",
+                "name": "Excavator",
+                "resource_type": ResourceType.EQUIPMENT,
+            }
+        )
+
+        resources, total = await repo.get_by_program(test_program.id)
+
+        assert total == 2
+        assert len(resources) == 2
+
+    async def test_get_by_program_with_type_filter(
+        self, db_session: AsyncSession, test_program: Program, test_resource: Resource
+    ) -> None:
+        """Test filtering resources by type."""
+        repo = ResourceRepository(db_session)
+
+        # Create equipment resource
+        await repo.create(
+            {
+                "program_id": test_program.id,
+                "code": "EQP-001",
+                "name": "Excavator",
+                "resource_type": ResourceType.EQUIPMENT,
+            }
+        )
+
+        # Filter by LABOR only
+        resources, total = await repo.get_by_program(
+            test_program.id, resource_type=ResourceType.LABOR
+        )
+
+        assert total == 1
+        assert resources[0].code == "ENG-001"
+
+    async def test_get_by_program_with_active_filter(
+        self, db_session: AsyncSession, test_program: Program, test_resource: Resource
+    ) -> None:
+        """Test filtering resources by active status."""
+        repo = ResourceRepository(db_session)
+
+        # Create inactive resource
+        await repo.create(
+            {
+                "program_id": test_program.id,
+                "code": "OLD-001",
+                "name": "Old Resource",
+                "is_active": False,
+            }
+        )
+
+        # Filter by active only
+        resources, total = await repo.get_by_program(test_program.id, is_active=True)
+
+        assert total == 1
+        assert resources[0].is_active is True
+
+    async def test_get_by_code(
+        self, db_session: AsyncSession, test_program: Program, test_resource: Resource
+    ) -> None:
+        """Test getting resource by code."""
+        repo = ResourceRepository(db_session)
+
+        resource = await repo.get_by_code(test_program.id, "ENG-001")
+
+        assert resource is not None
+        assert resource.code == "ENG-001"
+
+    async def test_get_by_code_case_insensitive(
+        self, db_session: AsyncSession, test_program: Program, test_resource: Resource
+    ) -> None:
+        """Test that code lookup is case-insensitive."""
+        repo = ResourceRepository(db_session)
+
+        resource = await repo.get_by_code(test_program.id, "eng-001")
+
+        assert resource is not None
+        assert resource.code == "ENG-001"
+
+    async def test_get_by_code_not_found(
+        self, db_session: AsyncSession, test_program: Program
+    ) -> None:
+        """Test getting non-existent resource by code."""
+        repo = ResourceRepository(db_session)
+
+        resource = await repo.get_by_code(test_program.id, "NONEXISTENT")
+
+        assert resource is None
+
+    async def test_code_exists(
+        self, db_session: AsyncSession, test_program: Program, test_resource: Resource
+    ) -> None:
+        """Test checking if code exists."""
+        repo = ResourceRepository(db_session)
+
+        exists = await repo.code_exists(test_program.id, "ENG-001")
+        assert exists is True
+
+        not_exists = await repo.code_exists(test_program.id, "NONEXISTENT")
+        assert not_exists is False
+
+    async def test_code_exists_with_exclude(
+        self, db_session: AsyncSession, test_program: Program, test_resource: Resource
+    ) -> None:
+        """Test code exists check with exclusion."""
+        repo = ResourceRepository(db_session)
+
+        # Should return False when excluding the resource itself
+        exists = await repo.code_exists(test_program.id, "ENG-001", exclude_id=test_resource.id)
+        assert exists is False
+
+    async def test_count_by_program(
+        self, db_session: AsyncSession, test_program: Program, test_resource: Resource
+    ) -> None:
+        """Test counting resources by program."""
+        repo = ResourceRepository(db_session)
+
+        count = await repo.count_by_program(test_program.id)
+        assert count == 1
+
+    async def test_get_with_assignments(
+        self,
+        db_session: AsyncSession,
+        test_resource: Resource,
+        test_activity: Activity,
+    ) -> None:
+        """Test getting resource with assignments eagerly loaded."""
+        # Create an assignment
+        assignment = ResourceAssignment(
+            id=uuid4(),
+            activity_id=test_activity.id,
+            resource_id=test_resource.id,
+            units=Decimal("1.0"),
+        )
+        db_session.add(assignment)
+        await db_session.flush()
+
+        repo = ResourceRepository(db_session)
+        resource = await repo.get_with_assignments(test_resource.id)
+
+        assert resource is not None
+        assert len(resource.assignments) == 1
+        assert resource.assignments[0].units == Decimal("1.0")
+
+
+# =============================================================================
+# ResourceAssignmentRepository Tests
+# =============================================================================
+
+
+class TestResourceAssignmentRepository:
+    """Tests for ResourceAssignmentRepository."""
+
+    async def test_create_assignment(
+        self,
+        db_session: AsyncSession,
+        test_resource: Resource,
+        test_activity: Activity,
+    ) -> None:
+        """Test creating a resource assignment."""
+        repo = ResourceAssignmentRepository(db_session)
+
+        assignment = await repo.create(
+            {
+                "activity_id": test_activity.id,
+                "resource_id": test_resource.id,
+                "units": Decimal("1.5"),
+                "start_date": date(2024, 1, 1),
+                "finish_date": date(2024, 1, 31),
+            }
+        )
+
+        assert assignment.id is not None
+        assert assignment.units == Decimal("1.5")
+
+    async def test_get_by_activity(
+        self,
+        db_session: AsyncSession,
+        test_resource: Resource,
+        test_activity: Activity,
+    ) -> None:
+        """Test getting assignments by activity."""
+        repo = ResourceAssignmentRepository(db_session)
+
+        # Create assignment
+        await repo.create(
+            {
+                "activity_id": test_activity.id,
+                "resource_id": test_resource.id,
+                "units": Decimal("1.0"),
+            }
+        )
+
+        assignments = await repo.get_by_activity(test_activity.id)
+
+        assert len(assignments) == 1
+        assert assignments[0].resource is not None  # Eagerly loaded
+        assert assignments[0].resource.code == "ENG-001"
+
+    async def test_get_by_resource(
+        self,
+        db_session: AsyncSession,
+        test_resource: Resource,
+        test_activity: Activity,
+    ) -> None:
+        """Test getting assignments by resource."""
+        repo = ResourceAssignmentRepository(db_session)
+
+        await repo.create(
+            {
+                "activity_id": test_activity.id,
+                "resource_id": test_resource.id,
+                "units": Decimal("1.0"),
+                "start_date": date(2024, 1, 15),
+                "finish_date": date(2024, 1, 31),
+            }
+        )
+
+        # Get all assignments
+        assignments = await repo.get_by_resource(test_resource.id)
+        assert len(assignments) == 1
+
+        # Filter by date range - should include
+        assignments = await repo.get_by_resource(
+            test_resource.id, start_date=date(2024, 1, 1), end_date=date(2024, 1, 20)
+        )
+        assert len(assignments) == 1
+
+        # Filter by date range - should exclude
+        assignments = await repo.get_by_resource(
+            test_resource.id, start_date=date(2024, 2, 1), end_date=date(2024, 2, 28)
+        )
+        assert len(assignments) == 0
+
+    async def test_assignment_exists(
+        self,
+        db_session: AsyncSession,
+        test_resource: Resource,
+        test_activity: Activity,
+    ) -> None:
+        """Test checking if assignment exists."""
+        repo = ResourceAssignmentRepository(db_session)
+
+        # No assignment yet
+        exists = await repo.assignment_exists(test_activity.id, test_resource.id)
+        assert exists is False
+
+        # Create assignment
+        await repo.create(
+            {
+                "activity_id": test_activity.id,
+                "resource_id": test_resource.id,
+                "units": Decimal("1.0"),
+            }
+        )
+
+        exists = await repo.assignment_exists(test_activity.id, test_resource.id)
+        assert exists is True
+
+    async def test_get_total_units_for_resource(
+        self,
+        db_session: AsyncSession,
+        test_program: Program,
+        test_wbs: WBSElement,
+        test_resource: Resource,
+    ) -> None:
+        """Test getting total allocation units for a resource on a date."""
+        repo = ResourceAssignmentRepository(db_session)
+
+        # Create two activities with assignments
+        activity1 = Activity(
+            id=uuid4(),
+            program_id=test_program.id,
+            wbs_id=test_wbs.id,
+            code="ACT-A",
+            name="Activity A",
+            duration=10,
+        )
+        activity2 = Activity(
+            id=uuid4(),
+            program_id=test_program.id,
+            wbs_id=test_wbs.id,
+            code="ACT-B",
+            name="Activity B",
+            duration=10,
+        )
+        db_session.add_all([activity1, activity2])
+        await db_session.flush()
+
+        # Create assignments overlapping on Jan 15
+        await repo.create(
+            {
+                "activity_id": activity1.id,
+                "resource_id": test_resource.id,
+                "units": Decimal("0.5"),
+                "start_date": date(2024, 1, 1),
+                "finish_date": date(2024, 1, 20),
+            }
+        )
+        await repo.create(
+            {
+                "activity_id": activity2.id,
+                "resource_id": test_resource.id,
+                "units": Decimal("0.75"),
+                "start_date": date(2024, 1, 10),
+                "finish_date": date(2024, 1, 31),
+            }
+        )
+
+        total = await repo.get_total_units_for_resource(test_resource.id, date(2024, 1, 15))
+        assert total == Decimal("1.25")
+
+
+# =============================================================================
+# ResourceCalendarRepository Tests
+# =============================================================================
+
+
+class TestResourceCalendarRepository:
+    """Tests for ResourceCalendarRepository."""
+
+    async def test_create_calendar_entry(
+        self, db_session: AsyncSession, test_resource: Resource
+    ) -> None:
+        """Test creating a calendar entry."""
+        repo = ResourceCalendarRepository(db_session)
+
+        entry = await repo.create(
+            {
+                "resource_id": test_resource.id,
+                "calendar_date": date(2024, 1, 15),
+                "available_hours": Decimal("8.0"),
+                "is_working_day": True,
+            }
+        )
+
+        assert entry.id is not None
+        assert entry.calendar_date == date(2024, 1, 15)
+        assert entry.available_hours == Decimal("8.0")
+
+    async def test_get_for_date_range(
+        self, db_session: AsyncSession, test_resource: Resource
+    ) -> None:
+        """Test getting calendar entries for a date range."""
+        repo = ResourceCalendarRepository(db_session)
+
+        # Create entries for a week
+        for i in range(7):
+            await repo.create(
+                {
+                    "resource_id": test_resource.id,
+                    "calendar_date": date(2024, 1, 1) + timedelta(days=i),
+                    "available_hours": Decimal("8.0") if i < 5 else Decimal("0.0"),
+                    "is_working_day": i < 5,  # Mon-Fri working
+                }
+            )
+
+        entries = await repo.get_for_date_range(
+            test_resource.id, date(2024, 1, 1), date(2024, 1, 7)
+        )
+
+        assert len(entries) == 7
+        # Check they're ordered by date
+        assert entries[0].calendar_date == date(2024, 1, 1)
+        assert entries[6].calendar_date == date(2024, 1, 7)
+
+    async def test_get_by_date(self, db_session: AsyncSession, test_resource: Resource) -> None:
+        """Test getting a calendar entry by date."""
+        repo = ResourceCalendarRepository(db_session)
+
+        await repo.create(
+            {
+                "resource_id": test_resource.id,
+                "calendar_date": date(2024, 1, 15),
+                "available_hours": Decimal("4.0"),
+                "is_working_day": True,
+            }
+        )
+
+        entry = await repo.get_by_date(test_resource.id, date(2024, 1, 15))
+
+        assert entry is not None
+        assert entry.available_hours == Decimal("4.0")
+
+    async def test_get_by_date_not_found(
+        self, db_session: AsyncSession, test_resource: Resource
+    ) -> None:
+        """Test getting non-existent calendar entry."""
+        repo = ResourceCalendarRepository(db_session)
+
+        entry = await repo.get_by_date(test_resource.id, date(2024, 1, 15))
+
+        assert entry is None
+
+    async def test_bulk_create_entries(
+        self, db_session: AsyncSession, test_resource: Resource
+    ) -> None:
+        """Test bulk creating calendar entries."""
+        repo = ResourceCalendarRepository(db_session)
+
+        entries_data = [
+            {
+                "resource_id": test_resource.id,
+                "calendar_date": date(2024, 1, 1) + timedelta(days=i),
+                "available_hours": Decimal("8.0"),
+                "is_working_day": True,
+            }
+            for i in range(5)
+        ]
+
+        entries = await repo.bulk_create_entries(entries_data)
+
+        assert len(entries) == 5
+
+    async def test_get_working_days_count(
+        self, db_session: AsyncSession, test_resource: Resource
+    ) -> None:
+        """Test counting working days in a range."""
+        repo = ResourceCalendarRepository(db_session)
+
+        # Create a week with 5 working days
+        for i in range(7):
+            await repo.create(
+                {
+                    "resource_id": test_resource.id,
+                    "calendar_date": date(2024, 1, 1) + timedelta(days=i),
+                    "available_hours": Decimal("8.0") if i < 5 else Decimal("0.0"),
+                    "is_working_day": i < 5,
+                }
+            )
+
+        count = await repo.get_working_days_count(
+            test_resource.id, date(2024, 1, 1), date(2024, 1, 7)
+        )
+
+        assert count == 5
+
+    async def test_get_total_hours(self, db_session: AsyncSession, test_resource: Resource) -> None:
+        """Test getting total hours in a range."""
+        repo = ResourceCalendarRepository(db_session)
+
+        # Create entries with varying hours
+        await repo.create(
+            {
+                "resource_id": test_resource.id,
+                "calendar_date": date(2024, 1, 1),
+                "available_hours": Decimal("8.0"),
+                "is_working_day": True,
+            }
+        )
+        await repo.create(
+            {
+                "resource_id": test_resource.id,
+                "calendar_date": date(2024, 1, 2),
+                "available_hours": Decimal("4.0"),
+                "is_working_day": True,
+            }
+        )
+        await repo.create(
+            {
+                "resource_id": test_resource.id,
+                "calendar_date": date(2024, 1, 3),
+                "available_hours": Decimal("6.0"),
+                "is_working_day": True,
+            }
+        )
+
+        total = await repo.get_total_hours(test_resource.id, date(2024, 1, 1), date(2024, 1, 3))
+
+        assert total == Decimal("18.0")
+
+    async def test_delete_range(self, db_session: AsyncSession, test_resource: Resource) -> None:
+        """Test deleting calendar entries in a range."""
+        repo = ResourceCalendarRepository(db_session)
+
+        # Create 10 days of entries
+        for i in range(10):
+            await repo.create(
+                {
+                    "resource_id": test_resource.id,
+                    "calendar_date": date(2024, 1, 1) + timedelta(days=i),
+                    "available_hours": Decimal("8.0"),
+                    "is_working_day": True,
+                }
+            )
+
+        # Delete middle 5 days
+        deleted_count = await repo.delete_range(
+            test_resource.id, date(2024, 1, 3), date(2024, 1, 7)
+        )
+
+        assert deleted_count == 5
+
+        # Verify remaining entries
+        remaining = await repo.get_for_date_range(
+            test_resource.id, date(2024, 1, 1), date(2024, 1, 10)
+        )
+        assert len(remaining) == 5


### PR DESCRIPTION
## Summary
- Add Resource, ResourceAssignment, and ResourceCalendar SQLAlchemy models
- Create repository layer with program-scoped queries and date range operations
- Add relationships to existing Program and Activity models
- Comprehensive integration tests for all repository methods

## Week 14 Resource Foundation Progress
This PR implements the second deliverable of Week 14: Repository layer for resource management.

### Models Created
| Model | Purpose |
|-------|---------|
| Resource | LABOR, EQUIPMENT, MATERIAL types with capacity and cost rates |
| ResourceAssignment | Activity-resource allocation with units (0-10) and date range |
| ResourceCalendar | Per-date availability with working day tracking |

### Repositories Created
| Repository | Key Methods |
|------------|-------------|
| ResourceRepository | get_by_program, get_by_code, code_exists, get_with_assignments |
| ResourceAssignmentRepository | get_by_activity, get_by_resource, get_total_units_for_resource |
| ResourceCalendarRepository | get_for_date_range, get_working_days_count, get_total_hours, delete_range |

### Model Relationships Added
- Program.resources (one-to-many)
- Activity.resource_assignments (one-to-many)
- Resource.assignments (one-to-many)
- Resource.calendar_entries (one-to-many)

## Test plan
- [x] 24 integration tests for repository operations
- [x] All 63 resource-related tests pass (24 repo + 39 schema)
- [x] Ruff linting passes
- [x] mypy type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)