### PR TITLE
feat(service): add ResourceService for loading calculations

### DIFF
--- a/api/src/services/resource.py
+++ b/api/src/services/resource.py
@@ -1,0 +1,387 @@
+"""Resource service for business logic and loading calculations.
+
+Provides resource management functionality including:
+- Resource loading calculations for date ranges
+- Overallocation detection
+- Program resource summary with caching
+- Default calendar generation
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from decimal import ROUND_HALF_UP, Decimal
+from typing import TYPE_CHECKING
+
+from src.models.enums import ResourceType
+from src.repositories.resource import (
+    ResourceAssignmentRepository,
+    ResourceCalendarRepository,
+    ResourceRepository,
+)
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from src.models.resource import ResourceAssignment, ResourceCalendar
+    from src.services.cache_service import CacheService
+
+
+# Cache TTL for resource summary (5 minutes)
+RESOURCE_SUMMARY_TTL = timedelta(minutes=5)
+
+
+@dataclass
+class ResourceLoadingDay:
+    """Resource loading data for a single day.
+
+    Attributes:
+        date: The calendar date
+        available_hours: Hours available based on calendar
+        assigned_hours: Hours assigned from all active assignments
+        utilization: Percentage of available hours that are assigned
+        is_overallocated: True if assigned > available
+    """
+
+    date: date
+    available_hours: Decimal
+    assigned_hours: Decimal
+    utilization: Decimal = field(init=False)
+    is_overallocated: bool = field(init=False)
+
+    def __post_init__(self) -> None:
+        """Calculate utilization and overallocation status."""
+        if self.available_hours > Decimal("0"):
+            self.utilization = (
+                (self.assigned_hours / self.available_hours) * Decimal("100")
+            ).quantize(Decimal("0.01"), rounding=ROUND_HALF_UP)
+        else:
+            # If no available hours, any assignment means overallocation
+            self.utilization = (
+                Decimal("100") if self.assigned_hours > Decimal("0") else Decimal("0")
+            )
+
+        self.is_overallocated = self.assigned_hours > self.available_hours
+
+
+@dataclass
+class ResourceSummaryStats:
+    """Summary statistics for program resources.
+
+    Attributes:
+        total_resources: Total count of resources
+        labor_count: Count of LABOR type resources
+        equipment_count: Count of EQUIPMENT type resources
+        material_count: Count of MATERIAL type resources
+        active_count: Count of active resources
+        inactive_count: Count of inactive resources
+    """
+
+    total_resources: int
+    labor_count: int
+    equipment_count: int
+    material_count: int
+    active_count: int
+    inactive_count: int
+
+    def model_dump(self) -> dict[str, int]:
+        """Convert to dictionary for caching."""
+        return {
+            "total_resources": self.total_resources,
+            "labor_count": self.labor_count,
+            "equipment_count": self.equipment_count,
+            "material_count": self.material_count,
+            "active_count": self.active_count,
+            "inactive_count": self.inactive_count,
+        }
+
+    @classmethod
+    def from_dict(cls, data: dict[str, int]) -> ResourceSummaryStats:
+        """Create from dictionary (for cache retrieval)."""
+        return cls(
+            total_resources=data["total_resources"],
+            labor_count=data["labor_count"],
+            equipment_count=data["equipment_count"],
+            material_count=data["material_count"],
+            active_count=data["active_count"],
+            inactive_count=data["inactive_count"],
+        )
+
+
+class ResourceService:
+    """Service for resource business logic and calculations.
+
+    Provides methods for:
+    - Calculating resource loading over date ranges
+    - Detecting overallocation
+    - Getting program resource summaries with caching
+    - Generating default calendars
+
+    Example usage:
+        service = ResourceService(session)
+        loading = await service.get_resource_loading(
+            resource_id,
+            date(2024, 1, 1),
+            date(2024, 1, 31)
+        )
+        for day in loading.values():
+            if day.is_overallocated:
+                print(f"Overallocated on {day.date}")
+    """
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        cache: CacheService | None = None,
+    ) -> None:
+        """Initialize ResourceService.
+
+        Args:
+            session: Database session for queries
+            cache: Optional cache service for summary caching
+        """
+        self.session = session
+        self.cache = cache
+        self._resource_repo = ResourceRepository(session)
+        self._assignment_repo = ResourceAssignmentRepository(session)
+        self._calendar_repo = ResourceCalendarRepository(session)
+
+    def _assignment_active_on_date(
+        self,
+        assignment: ResourceAssignment,
+        check_date: date,
+    ) -> bool:
+        """Check if an assignment is active on a specific date.
+
+        An assignment is active if:
+        - It has no start_date or start_date <= check_date
+        - It has no finish_date or finish_date >= check_date
+
+        Args:
+            assignment: The resource assignment to check
+            check_date: The date to check against
+
+        Returns:
+            True if assignment is active on the date
+        """
+        # Check start constraint (no start_date or start_date <= check_date)
+        start_ok = not assignment.start_date or assignment.start_date <= check_date
+        # Check finish constraint (no finish_date or finish_date >= check_date)
+        finish_ok = not assignment.finish_date or assignment.finish_date >= check_date
+        return start_ok and finish_ok
+
+    async def get_resource_loading(
+        self,
+        resource_id: UUID,
+        start_date: date,
+        end_date: date,
+    ) -> dict[date, ResourceLoadingDay]:
+        """Calculate resource loading for each day in a date range.
+
+        Combines calendar availability with assignment allocations to
+        calculate daily utilization and identify overallocations.
+
+        Args:
+            resource_id: The resource to calculate loading for
+            start_date: Start of date range (inclusive)
+            end_date: End of date range (inclusive)
+
+        Returns:
+            Dictionary mapping dates to ResourceLoadingDay objects
+        """
+        # Get resource to check capacity
+        resource = await self._resource_repo.get_by_id(resource_id)
+        if not resource:
+            return {}
+
+        default_capacity = resource.capacity_per_day
+
+        # Get calendar entries for the range
+        calendar_entries = await self._calendar_repo.get_for_date_range(
+            resource_id, start_date, end_date
+        )
+
+        # Build calendar lookup
+        calendar_by_date: dict[date, ResourceCalendar] = {
+            entry.calendar_date: entry for entry in calendar_entries
+        }
+
+        # Get all assignments that might overlap this range
+        assignments = await self._assignment_repo.get_by_resource(
+            resource_id, start_date=start_date, end_date=end_date
+        )
+
+        # Calculate loading for each day
+        loading: dict[date, ResourceLoadingDay] = {}
+        current_date = start_date
+
+        while current_date <= end_date:
+            # Get available hours from calendar or default
+            if current_date in calendar_by_date:
+                calendar_entry = calendar_by_date[current_date]
+                available_hours = (
+                    calendar_entry.available_hours
+                    if calendar_entry.is_working_day
+                    else Decimal("0")
+                )
+            # No calendar entry - use default capacity for weekdays
+            elif current_date.weekday() < 5:  # Monday = 0, Friday = 4
+                available_hours = default_capacity
+            else:
+                available_hours = Decimal("0")
+
+            # Calculate assigned hours from active assignments
+            assigned_hours = Decimal("0")
+            for assignment in assignments:
+                if self._assignment_active_on_date(assignment, current_date):
+                    # Units represent allocation (1.0 = 100% = full capacity)
+                    assigned_hours += assignment.units * default_capacity
+
+            loading[current_date] = ResourceLoadingDay(
+                date=current_date,
+                available_hours=available_hours,
+                assigned_hours=assigned_hours.quantize(Decimal("0.01"), rounding=ROUND_HALF_UP),
+            )
+
+            current_date += timedelta(days=1)
+
+        return loading
+
+    async def get_overallocated_dates(
+        self,
+        resource_id: UUID,
+        start_date: date,
+        end_date: date,
+    ) -> list[date]:
+        """Get list of dates where resource is overallocated.
+
+        Args:
+            resource_id: The resource to check
+            start_date: Start of date range (inclusive)
+            end_date: End of date range (inclusive)
+
+        Returns:
+            List of dates where assigned hours exceed available hours
+        """
+        loading = await self.get_resource_loading(resource_id, start_date, end_date)
+
+        return [day.date for day in loading.values() if day.is_overallocated]
+
+    async def get_program_resource_summary(
+        self,
+        program_id: UUID,
+    ) -> ResourceSummaryStats:
+        """Get summary statistics for program resources.
+
+        Uses caching when available (5-minute TTL).
+
+        Args:
+            program_id: The program to get summary for
+
+        Returns:
+            ResourceSummaryStats with counts by type and status
+        """
+        cache_key = f"resource_summary:{program_id}"
+
+        # Try cache first
+        if self.cache and self.cache.is_available:
+            cached = await self.cache.get(cache_key, "resource_summary")
+            if cached:
+                return ResourceSummaryStats.from_dict(cached)
+
+        # Calculate from database
+        total = await self._resource_repo.count_by_program(program_id)
+        labor = await self._resource_repo.count_by_program(
+            program_id, resource_type=ResourceType.LABOR
+        )
+        equipment = await self._resource_repo.count_by_program(
+            program_id, resource_type=ResourceType.EQUIPMENT
+        )
+        material = await self._resource_repo.count_by_program(
+            program_id, resource_type=ResourceType.MATERIAL
+        )
+        active = await self._resource_repo.count_by_program(program_id, is_active=True)
+        inactive = await self._resource_repo.count_by_program(program_id, is_active=False)
+
+        summary = ResourceSummaryStats(
+            total_resources=total,
+            labor_count=labor,
+            equipment_count=equipment,
+            material_count=material,
+            active_count=active,
+            inactive_count=inactive,
+        )
+
+        # Cache the result
+        if self.cache and self.cache.is_available:
+            await self.cache.set(
+                cache_key,
+                summary.model_dump(),
+                RESOURCE_SUMMARY_TTL,
+                "resource_summary",
+            )
+
+        return summary
+
+    async def generate_default_calendar(
+        self,
+        resource_id: UUID,
+        start_date: date,
+        end_date: date,
+        hours_per_day: Decimal = Decimal("8.0"),
+        include_weekends: bool = False,
+    ) -> list[ResourceCalendar]:
+        """Generate default calendar entries for a resource.
+
+        Creates calendar entries for each day in the range based on
+        weekday/weekend logic.
+
+        Args:
+            resource_id: The resource to create calendar for
+            start_date: Start of date range (inclusive)
+            end_date: End of date range (inclusive)
+            hours_per_day: Default hours for working days
+            include_weekends: If True, weekends are working days
+
+        Returns:
+            List of created ResourceCalendar entries
+        """
+        entries_data: list[dict[str, object]] = []
+        current_date = start_date
+
+        while current_date <= end_date:
+            is_weekend = current_date.weekday() >= 5  # Saturday = 5, Sunday = 6
+
+            if include_weekends or not is_weekend:
+                # Working day
+                entries_data.append(
+                    {
+                        "resource_id": resource_id,
+                        "calendar_date": current_date,
+                        "available_hours": hours_per_day,
+                        "is_working_day": True,
+                    }
+                )
+            else:
+                # Weekend (non-working)
+                entries_data.append(
+                    {
+                        "resource_id": resource_id,
+                        "calendar_date": current_date,
+                        "available_hours": Decimal("0"),
+                        "is_working_day": False,
+                    }
+                )
+
+            current_date += timedelta(days=1)
+
+        # Delete existing entries in range first
+        await self._calendar_repo.delete_range(resource_id, start_date, end_date)
+
+        # Create new entries
+        entries = await self._calendar_repo.bulk_create_entries(entries_data)
+
+        return entries

--- a/api/tests/unit/test_resource_service.py
+++ b/api/tests/unit/test_resource_service.py
@@ -1,0 +1,538 @@
+"""Unit tests for ResourceService."""
+
+from datetime import date
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock, patch
+from uuid import uuid4
+
+import pytest
+
+from src.services.resource import (
+    ResourceLoadingDay,
+    ResourceService,
+    ResourceSummaryStats,
+)
+
+# =============================================================================
+# ResourceLoadingDay Tests
+# =============================================================================
+
+
+class TestResourceLoadingDay:
+    """Tests for ResourceLoadingDay dataclass."""
+
+    def test_loading_day_normal_utilization(self) -> None:
+        """Test loading day with normal utilization."""
+        day = ResourceLoadingDay(
+            date=date(2024, 1, 15),
+            available_hours=Decimal("8.0"),
+            assigned_hours=Decimal("4.0"),
+        )
+
+        assert day.utilization == Decimal("50.00")
+        assert day.is_overallocated is False
+
+    def test_loading_day_full_utilization(self) -> None:
+        """Test loading day at 100% utilization."""
+        day = ResourceLoadingDay(
+            date=date(2024, 1, 15),
+            available_hours=Decimal("8.0"),
+            assigned_hours=Decimal("8.0"),
+        )
+
+        assert day.utilization == Decimal("100.00")
+        assert day.is_overallocated is False
+
+    def test_loading_day_overallocated(self) -> None:
+        """Test loading day with overallocation."""
+        day = ResourceLoadingDay(
+            date=date(2024, 1, 15),
+            available_hours=Decimal("8.0"),
+            assigned_hours=Decimal("12.0"),
+        )
+
+        assert day.utilization == Decimal("150.00")
+        assert day.is_overallocated is True
+
+    def test_loading_day_zero_available(self) -> None:
+        """Test loading day with zero available hours."""
+        day = ResourceLoadingDay(
+            date=date(2024, 1, 15),
+            available_hours=Decimal("0"),
+            assigned_hours=Decimal("0"),
+        )
+
+        assert day.utilization == Decimal("0")
+        assert day.is_overallocated is False
+
+    def test_loading_day_zero_available_with_assignment(self) -> None:
+        """Test loading day with zero available but assigned hours."""
+        day = ResourceLoadingDay(
+            date=date(2024, 1, 15),
+            available_hours=Decimal("0"),
+            assigned_hours=Decimal("4.0"),
+        )
+
+        assert day.utilization == Decimal("100")
+        assert day.is_overallocated is True
+
+    def test_loading_day_partial_hours(self) -> None:
+        """Test loading day with fractional hours."""
+        day = ResourceLoadingDay(
+            date=date(2024, 1, 15),
+            available_hours=Decimal("8.0"),
+            assigned_hours=Decimal("2.5"),
+        )
+
+        assert day.utilization == Decimal("31.25")
+        assert day.is_overallocated is False
+
+
+# =============================================================================
+# ResourceSummaryStats Tests
+# =============================================================================
+
+
+class TestResourceSummaryStats:
+    """Tests for ResourceSummaryStats dataclass."""
+
+    def test_summary_stats_creation(self) -> None:
+        """Test creating summary stats."""
+        stats = ResourceSummaryStats(
+            total_resources=10,
+            labor_count=5,
+            equipment_count=3,
+            material_count=2,
+            active_count=8,
+            inactive_count=2,
+        )
+
+        assert stats.total_resources == 10
+        assert stats.labor_count == 5
+        assert stats.equipment_count == 3
+        assert stats.material_count == 2
+        assert stats.active_count == 8
+        assert stats.inactive_count == 2
+
+    def test_summary_stats_model_dump(self) -> None:
+        """Test model_dump for caching."""
+        stats = ResourceSummaryStats(
+            total_resources=10,
+            labor_count=5,
+            equipment_count=3,
+            material_count=2,
+            active_count=8,
+            inactive_count=2,
+        )
+
+        dumped = stats.model_dump()
+
+        assert dumped == {
+            "total_resources": 10,
+            "labor_count": 5,
+            "equipment_count": 3,
+            "material_count": 2,
+            "active_count": 8,
+            "inactive_count": 2,
+        }
+
+    def test_summary_stats_from_dict(self) -> None:
+        """Test creating from dictionary (cache retrieval)."""
+        data = {
+            "total_resources": 15,
+            "labor_count": 7,
+            "equipment_count": 5,
+            "material_count": 3,
+            "active_count": 12,
+            "inactive_count": 3,
+        }
+
+        stats = ResourceSummaryStats.from_dict(data)
+
+        assert stats.total_resources == 15
+        assert stats.labor_count == 7
+        assert stats.equipment_count == 5
+        assert stats.material_count == 3
+        assert stats.active_count == 12
+        assert stats.inactive_count == 3
+
+
+# =============================================================================
+# ResourceService Assignment Active Tests
+# =============================================================================
+
+
+class TestResourceServiceAssignmentActive:
+    """Tests for _assignment_active_on_date method."""
+
+    @pytest.fixture
+    def service(self) -> ResourceService:
+        """Create service with mock session."""
+        mock_session = MagicMock()
+        return ResourceService(mock_session)
+
+    def test_assignment_no_dates_always_active(self, service: ResourceService) -> None:
+        """Test assignment with no start/finish dates is always active."""
+        assignment = MagicMock()
+        assignment.start_date = None
+        assignment.finish_date = None
+
+        # Active on any date
+        assert service._assignment_active_on_date(assignment, date(2024, 1, 1)) is True
+        assert service._assignment_active_on_date(assignment, date(2024, 6, 15)) is True
+        assert service._assignment_active_on_date(assignment, date(2024, 12, 31)) is True
+
+    def test_assignment_with_start_date_only(self, service: ResourceService) -> None:
+        """Test assignment with only start date."""
+        assignment = MagicMock()
+        assignment.start_date = date(2024, 3, 1)
+        assignment.finish_date = None
+
+        # Not active before start
+        assert service._assignment_active_on_date(assignment, date(2024, 2, 28)) is False
+
+        # Active on and after start
+        assert service._assignment_active_on_date(assignment, date(2024, 3, 1)) is True
+        assert service._assignment_active_on_date(assignment, date(2024, 12, 31)) is True
+
+    def test_assignment_with_finish_date_only(self, service: ResourceService) -> None:
+        """Test assignment with only finish date."""
+        assignment = MagicMock()
+        assignment.start_date = None
+        assignment.finish_date = date(2024, 6, 30)
+
+        # Active before and on finish
+        assert service._assignment_active_on_date(assignment, date(2024, 1, 1)) is True
+        assert service._assignment_active_on_date(assignment, date(2024, 6, 30)) is True
+
+        # Not active after finish
+        assert service._assignment_active_on_date(assignment, date(2024, 7, 1)) is False
+
+    def test_assignment_with_date_range(self, service: ResourceService) -> None:
+        """Test assignment with both start and finish dates."""
+        assignment = MagicMock()
+        assignment.start_date = date(2024, 3, 1)
+        assignment.finish_date = date(2024, 6, 30)
+
+        # Not active before start
+        assert service._assignment_active_on_date(assignment, date(2024, 2, 28)) is False
+
+        # Active within range
+        assert service._assignment_active_on_date(assignment, date(2024, 3, 1)) is True
+        assert service._assignment_active_on_date(assignment, date(2024, 4, 15)) is True
+        assert service._assignment_active_on_date(assignment, date(2024, 6, 30)) is True
+
+        # Not active after finish
+        assert service._assignment_active_on_date(assignment, date(2024, 7, 1)) is False
+
+    def test_assignment_single_day(self, service: ResourceService) -> None:
+        """Test assignment active for single day."""
+        assignment = MagicMock()
+        assignment.start_date = date(2024, 5, 15)
+        assignment.finish_date = date(2024, 5, 15)
+
+        # Only active on that exact day
+        assert service._assignment_active_on_date(assignment, date(2024, 5, 14)) is False
+        assert service._assignment_active_on_date(assignment, date(2024, 5, 15)) is True
+        assert service._assignment_active_on_date(assignment, date(2024, 5, 16)) is False
+
+
+# =============================================================================
+# ResourceService Loading Calculation Tests
+# =============================================================================
+
+
+class TestResourceServiceLoading:
+    """Tests for resource loading calculations."""
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create mock session."""
+        return MagicMock()
+
+    @pytest.fixture
+    def service(self, mock_session: MagicMock) -> ResourceService:
+        """Create service with mocked repositories."""
+        return ResourceService(mock_session)
+
+    @pytest.mark.asyncio
+    async def test_get_resource_loading_no_resource(self, service: ResourceService) -> None:
+        """Test loading calculation when resource doesn't exist."""
+        resource_id = uuid4()
+
+        with patch.object(service._resource_repo, "get_by_id", new_callable=AsyncMock) as mock_get:
+            mock_get.return_value = None
+
+            loading = await service.get_resource_loading(
+                resource_id, date(2024, 1, 1), date(2024, 1, 5)
+            )
+
+            assert loading == {}
+
+    @pytest.mark.asyncio
+    async def test_get_resource_loading_with_calendar(self, service: ResourceService) -> None:
+        """Test loading with calendar entries."""
+        resource_id = uuid4()
+
+        # Mock resource
+        mock_resource = MagicMock()
+        mock_resource.capacity_per_day = Decimal("8.0")
+
+        # Mock calendar entry
+        mock_calendar = MagicMock()
+        mock_calendar.calendar_date = date(2024, 1, 15)
+        mock_calendar.available_hours = Decimal("6.0")
+        mock_calendar.is_working_day = True
+
+        with (
+            patch.object(
+                service._resource_repo, "get_by_id", new_callable=AsyncMock
+            ) as mock_get_resource,
+            patch.object(
+                service._calendar_repo, "get_for_date_range", new_callable=AsyncMock
+            ) as mock_get_calendar,
+            patch.object(
+                service._assignment_repo, "get_by_resource", new_callable=AsyncMock
+            ) as mock_get_assignments,
+        ):
+            mock_get_resource.return_value = mock_resource
+            mock_get_calendar.return_value = [mock_calendar]
+            mock_get_assignments.return_value = []
+
+            loading = await service.get_resource_loading(
+                resource_id, date(2024, 1, 15), date(2024, 1, 15)
+            )
+
+            assert len(loading) == 1
+            assert loading[date(2024, 1, 15)].available_hours == Decimal("6.0")
+            assert loading[date(2024, 1, 15)].assigned_hours == Decimal("0")
+
+    @pytest.mark.asyncio
+    async def test_get_overallocated_dates(self, service: ResourceService) -> None:
+        """Test finding overallocated dates."""
+        resource_id = uuid4()
+
+        # Create loading with one overallocated day
+        loading = {
+            date(2024, 1, 15): ResourceLoadingDay(
+                date=date(2024, 1, 15),
+                available_hours=Decimal("8.0"),
+                assigned_hours=Decimal("4.0"),
+            ),
+            date(2024, 1, 16): ResourceLoadingDay(
+                date=date(2024, 1, 16),
+                available_hours=Decimal("8.0"),
+                assigned_hours=Decimal("12.0"),  # Overallocated
+            ),
+            date(2024, 1, 17): ResourceLoadingDay(
+                date=date(2024, 1, 17),
+                available_hours=Decimal("8.0"),
+                assigned_hours=Decimal("8.0"),
+            ),
+        }
+
+        with patch.object(service, "get_resource_loading", new_callable=AsyncMock) as mock_loading:
+            mock_loading.return_value = loading
+
+            overallocated = await service.get_overallocated_dates(
+                resource_id, date(2024, 1, 15), date(2024, 1, 17)
+            )
+
+            assert len(overallocated) == 1
+            assert date(2024, 1, 16) in overallocated
+
+
+# =============================================================================
+# ResourceService Summary Tests
+# =============================================================================
+
+
+class TestResourceServiceSummary:
+    """Tests for program resource summary."""
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create mock session."""
+        return MagicMock()
+
+    @pytest.mark.asyncio
+    async def test_get_program_resource_summary_no_cache(self, mock_session: MagicMock) -> None:
+        """Test summary calculation without cache."""
+        service = ResourceService(mock_session, cache=None)
+        program_id = uuid4()
+
+        with patch.object(
+            service._resource_repo, "count_by_program", new_callable=AsyncMock
+        ) as mock_count:
+            # Set up return values for each call
+            mock_count.side_effect = [10, 5, 3, 2, 8, 2]
+
+            summary = await service.get_program_resource_summary(program_id)
+
+            assert summary.total_resources == 10
+            assert summary.labor_count == 5
+            assert summary.equipment_count == 3
+            assert summary.material_count == 2
+            assert summary.active_count == 8
+            assert summary.inactive_count == 2
+
+    @pytest.mark.asyncio
+    async def test_get_program_resource_summary_with_cache_hit(
+        self, mock_session: MagicMock
+    ) -> None:
+        """Test summary retrieval from cache."""
+        mock_cache = MagicMock()
+        mock_cache.is_available = True
+        mock_cache.get = AsyncMock(
+            return_value={
+                "total_resources": 15,
+                "labor_count": 7,
+                "equipment_count": 5,
+                "material_count": 3,
+                "active_count": 12,
+                "inactive_count": 3,
+            }
+        )
+
+        service = ResourceService(mock_session, cache=mock_cache)
+        program_id = uuid4()
+
+        summary = await service.get_program_resource_summary(program_id)
+
+        assert summary.total_resources == 15
+        mock_cache.get.assert_called_once()
+
+    @pytest.mark.asyncio
+    async def test_get_program_resource_summary_cache_miss(self, mock_session: MagicMock) -> None:
+        """Test summary calculation on cache miss."""
+        mock_cache = MagicMock()
+        mock_cache.is_available = True
+        mock_cache.get = AsyncMock(return_value=None)
+        mock_cache.set = AsyncMock()
+
+        service = ResourceService(mock_session, cache=mock_cache)
+        program_id = uuid4()
+
+        with patch.object(
+            service._resource_repo, "count_by_program", new_callable=AsyncMock
+        ) as mock_count:
+            mock_count.side_effect = [10, 5, 3, 2, 8, 2]
+
+            summary = await service.get_program_resource_summary(program_id)
+
+            assert summary.total_resources == 10
+            mock_cache.set.assert_called_once()
+
+
+# =============================================================================
+# ResourceService Calendar Generation Tests
+# =============================================================================
+
+
+class TestResourceServiceCalendarGeneration:
+    """Tests for default calendar generation."""
+
+    @pytest.fixture
+    def mock_session(self) -> MagicMock:
+        """Create mock session."""
+        return MagicMock()
+
+    @pytest.fixture
+    def service(self, mock_session: MagicMock) -> ResourceService:
+        """Create service."""
+        return ResourceService(mock_session)
+
+    @pytest.mark.asyncio
+    async def test_generate_default_calendar_weekdays_only(self, service: ResourceService) -> None:
+        """Test generating calendar excluding weekends."""
+        resource_id = uuid4()
+
+        # Monday to Friday (Jan 15-19, 2024)
+        start_date = date(2024, 1, 15)
+        end_date = date(2024, 1, 19)
+
+        mock_entries = [MagicMock() for _ in range(5)]
+
+        with (
+            patch.object(
+                service._calendar_repo, "delete_range", new_callable=AsyncMock
+            ) as mock_delete,
+            patch.object(
+                service._calendar_repo, "bulk_create_entries", new_callable=AsyncMock
+            ) as mock_create,
+        ):
+            mock_create.return_value = mock_entries
+
+            entries = await service.generate_default_calendar(
+                resource_id, start_date, end_date, include_weekends=False
+            )
+
+            assert len(entries) == 5
+            mock_delete.assert_called_once_with(resource_id, start_date, end_date)
+
+            # Verify entries data
+            create_call_args = mock_create.call_args[0][0]
+            assert len(create_call_args) == 5
+            # All should be working days with 8 hours
+            for entry_data in create_call_args:
+                assert entry_data["available_hours"] == Decimal("8.0")
+                assert entry_data["is_working_day"] is True
+
+    @pytest.mark.asyncio
+    async def test_generate_default_calendar_with_weekends(self, service: ResourceService) -> None:
+        """Test generating calendar including weekends."""
+        resource_id = uuid4()
+
+        # Full week including weekend (Jan 15-21, 2024)
+        start_date = date(2024, 1, 15)  # Monday
+        end_date = date(2024, 1, 21)  # Sunday
+
+        mock_entries = [MagicMock() for _ in range(7)]
+
+        with (
+            patch.object(service._calendar_repo, "delete_range", new_callable=AsyncMock),
+            patch.object(
+                service._calendar_repo, "bulk_create_entries", new_callable=AsyncMock
+            ) as mock_create,
+        ):
+            mock_create.return_value = mock_entries
+
+            entries = await service.generate_default_calendar(
+                resource_id, start_date, end_date, include_weekends=True
+            )
+
+            assert len(entries) == 7
+
+            # Verify all 7 days are working days
+            create_call_args = mock_create.call_args[0][0]
+            assert len(create_call_args) == 7
+            for entry_data in create_call_args:
+                assert entry_data["is_working_day"] is True
+
+    @pytest.mark.asyncio
+    async def test_generate_default_calendar_custom_hours(self, service: ResourceService) -> None:
+        """Test generating calendar with custom hours."""
+        resource_id = uuid4()
+
+        start_date = date(2024, 1, 15)
+        end_date = date(2024, 1, 15)
+
+        mock_entries = [MagicMock()]
+
+        with (
+            patch.object(service._calendar_repo, "delete_range", new_callable=AsyncMock),
+            patch.object(
+                service._calendar_repo, "bulk_create_entries", new_callable=AsyncMock
+            ) as mock_create,
+        ):
+            mock_create.return_value = mock_entries
+
+            await service.generate_default_calendar(
+                resource_id,
+                start_date,
+                end_date,
+                hours_per_day=Decimal("10.0"),
+            )
+
+            create_call_args = mock_create.call_args[0][0]
+            assert create_call_args[0]["available_hours"] == Decimal("10.0")


### PR DESCRIPTION
## Summary

- Add ResourceService with resource loading and overallocation calculations
- Add ResourceLoadingDay dataclass for daily utilization tracking
- Add ResourceSummaryStats dataclass with model_dump/from_dict for caching
- Implement get_resource_loading() for calculating daily available/assigned hours
- Implement get_overallocated_dates() to detect resource conflicts
- Implement get_program_resource_summary() with 5-minute cache TTL
- Implement generate_default_calendar() for default weekday/weekend calendar creation
- Add 23 unit tests covering all service methods

## Test plan
- [x] Linting passes (`ruff check`)
- [x] Type checking passes (`mypy`)
- [x] Unit tests pass (23 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)