### PR TITLE
fix(migrations): repair Alembic migration chain and LTREE type

### DIFF
--- a/api/alembic/versions/001_initial_schema.py
+++ b/api/alembic/versions/001_initial_schema.py
@@ -26,9 +26,25 @@ from uuid import uuid4
 from alembic import op
 import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
+from sqlalchemy.types import UserDefinedType
+
+
+class LTREE(UserDefinedType):
+    """PostgreSQL ltree type for hierarchical data."""
+    cache_ok = True
+
+    def get_col_spec(self):
+        return "LTREE"
+
+    def bind_processor(self, dialect):
+        return None
+
+    def result_processor(self, dialect, coltype):
+        return None
+
 
 # Revision identifiers, used by Alembic.
-revision: str = "001"
+revision: str = "001_initial_schema"
 down_revision: Union[str, None] = None
 branch_labels: Union[str, Sequence[str], None] = None
 depends_on: Union[str, Sequence[str], None] = None
@@ -352,7 +368,7 @@ def upgrade() -> None:
         # Hierarchy using ltree
         sa.Column(
             "path",
-            postgresql.LTREE,
+            LTREE(),
             nullable=False,
             comment="ltree path for hierarchy queries",
         ),

--- a/api/alembic/versions/002_evms_periods.py
+++ b/api/alembic/versions/002_evms_periods.py
@@ -25,7 +25,7 @@ def upgrade() -> None:
         "approved",
         "rejected",
         name="period_status",
-        create_type=True,
+        create_type=False,  # We create it explicitly below
     )
     period_status_enum.create(op.get_bind(), checkfirst=True)
 

--- a/api/alembic/versions/006_simulations.py
+++ b/api/alembic/versions/006_simulations.py
@@ -15,8 +15,8 @@ import sqlalchemy as sa
 from sqlalchemy.dialects import postgresql
 
 # revision identifiers, used by Alembic.
-revision = "006"
-down_revision = "005"
+revision = "006_simulations"
+down_revision = "005_scenarios"
 branch_labels = None
 depends_on = None
 

--- a/api/alembic/versions/007_variance_and_audit.py
+++ b/api/alembic/versions/007_variance_and_audit.py
@@ -15,8 +15,8 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import UUID, JSONB
 
 # revision identifiers, used by Alembic.
-revision = "007"
-down_revision = "006"
+revision = "007_variance_and_audit"
+down_revision = "006_simulations"
 branch_labels = None
 depends_on = None
 
@@ -29,7 +29,7 @@ def upgrade() -> None:
         sa.Column(
             "program_id", UUID(as_uuid=True), sa.ForeignKey("programs.id"), nullable=False
         ),
-        sa.Column("wbs_id", UUID(as_uuid=True), sa.ForeignKey("wbs.id"), nullable=True),
+        sa.Column("wbs_id", UUID(as_uuid=True), sa.ForeignKey("wbs_elements.id"), nullable=True),
         sa.Column(
             "period_id", UUID(as_uuid=True), sa.ForeignKey("evms_periods.id"), nullable=True
         ),

--- a/api/alembic/versions/008_jira_integration.py
+++ b/api/alembic/versions/008_jira_integration.py
@@ -15,8 +15,8 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import UUID
 
 # revision identifiers, used by Alembic.
-revision = "008"
-down_revision = "007"
+revision = "008_jira_integration"
+down_revision = "007_variance_and_audit"
 branch_labels = None
 depends_on = None
 

--- a/api/alembic/versions/009_api_keys.py
+++ b/api/alembic/versions/009_api_keys.py
@@ -13,8 +13,8 @@ import sqlalchemy as sa
 from sqlalchemy.dialects.postgresql import UUID
 
 # revision identifiers, used by Alembic.
-revision = "009"
-down_revision = "008"
+revision = "009_api_keys"
+down_revision = "008_jira_integration"
 branch_labels = None
 depends_on = None
 


### PR DESCRIPTION
## Summary

- Add custom `LTREE` UserDefinedType class for PostgreSQL ltree support (not built-in to SQLAlchemy)
- Fix broken revision chain in migrations 001→009 with consistent naming convention
- Fix duplicate `period_status` enum creation error by setting `create_type=False`
- Fix incorrect foreign key reference from `wbs.id` to `wbs_elements.id`

## Test plan

- [x] Verified all 9 migrations run successfully on fresh database
- [x] Confirmed 20 tables created correctly
- [x] Verified ltree extension is enabled
- [x] Tested `alembic current` shows `009_api_keys (head)`
- [ ] Run full test suite to ensure no regressions

## Changes

| File | Change |
|------|--------|
| `001_initial_schema.py` | Added LTREE type class, fixed revision ID |
| `002_evms_periods.py` | Fixed `create_type=False` for enum |
| `006_simulations.py` | Fixed revision/down_revision naming |
| `007_variance_and_audit.py` | Fixed revision naming + wbs_elements FK |
| `008_jira_integration.py` | Fixed revision/down_revision naming |
| `009_api_keys.py` | Fixed revision/down_revision naming |

🤖 Generated with [Claude Code](https://claude.com/claude-code)