### PR TITLE
feat(api): add resource leveling API endpoints

### DIFF
--- a/api/src/api/v1/endpoints/leveling.py
+++ b/api/src/api/v1/endpoints/leveling.py
@@ -1,0 +1,232 @@
+"""API endpoints for resource leveling."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query
+
+from src.core.deps import CurrentUser, DbSession
+from src.repositories.activity import ActivityRepository
+from src.repositories.program import ProgramRepository
+from src.schemas.leveling import (
+    ActivityShiftResponse,
+    LevelingApplyRequest,
+    LevelingApplyResponse,
+    LevelingOptionsRequest,
+    LevelingResultResponse,
+)
+from src.services.resource_leveling import (
+    LevelingOptions,
+    LevelingResult,
+    ResourceLevelingService,
+)
+
+if TYPE_CHECKING:
+    from datetime import date
+
+router = APIRouter(prefix="/programs", tags=["leveling"])
+
+
+def _convert_result_to_response(
+    result: LevelingResult,
+) -> LevelingResultResponse:
+    """Convert LevelingResult dataclass to response schema."""
+    shifts = [
+        ActivityShiftResponse(
+            activity_id=s.activity_id,
+            activity_code=s.activity_code,
+            original_start=s.original_start,
+            original_finish=s.original_finish,
+            new_start=s.new_start,
+            new_finish=s.new_finish,
+            delay_days=s.delay_days,
+            reason=s.reason,
+        )
+        for s in result.shifts
+    ]
+
+    return LevelingResultResponse(
+        program_id=result.program_id,
+        success=result.success,
+        iterations_used=result.iterations_used,
+        activities_shifted=result.activities_shifted,
+        shifts=shifts,
+        remaining_overallocations=result.remaining_overallocations,
+        new_project_finish=result.new_project_finish,
+        original_project_finish=result.original_project_finish,
+        schedule_extension_days=result.schedule_extension_days,
+        warnings=result.warnings,
+    )
+
+
+@router.post(
+    "/{program_id}/level",
+    response_model=LevelingResultResponse,
+    summary="Run resource leveling",
+)
+async def level_program_resources(
+    program_id: UUID,
+    options: LevelingOptionsRequest,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> LevelingResultResponse:
+    """Run resource leveling algorithm on program.
+
+    Returns proposed activity shifts without applying them.
+    Use /level/apply to apply selected shifts.
+
+    Args:
+        program_id: UUID of the program to level
+        options: Leveling configuration options
+        db: Database session
+        current_user: Authenticated user
+
+    Returns:
+        LevelingResultResponse with proposed shifts
+
+    Raises:
+        HTTPException: 404 if program not found
+    """
+    program_repo = ProgramRepository(db)
+    program = await program_repo.get_by_id(program_id)
+
+    if not program:
+        raise HTTPException(status_code=404, detail="Program not found")
+
+    # Run leveling
+    service = ResourceLevelingService(db)
+    leveling_options = LevelingOptions(
+        preserve_critical_path=options.preserve_critical_path,
+        max_iterations=options.max_iterations,
+        target_resources=options.target_resources,
+        level_within_float=options.level_within_float,
+    )
+    result = await service.level_program(program_id, leveling_options)
+
+    return _convert_result_to_response(result)
+
+
+@router.get(
+    "/{program_id}/level/preview",
+    response_model=LevelingResultResponse,
+    summary="Preview resource leveling",
+)
+async def preview_leveling(
+    program_id: UUID,
+    db: DbSession,
+    current_user: CurrentUser,
+    preserve_critical_path: bool = Query(default=True),
+    level_within_float: bool = Query(default=True),
+    max_iterations: int = Query(default=100, ge=1, le=1000),
+    target_resources: list[UUID] | None = Query(default=None),
+) -> LevelingResultResponse:
+    """Preview resource leveling without applying changes.
+
+    Same as POST /level but as GET for easier testing.
+
+    Args:
+        program_id: UUID of the program to level
+        preserve_critical_path: Don't delay critical activities
+        level_within_float: Only delay within float
+        max_iterations: Maximum iterations
+        target_resources: Specific resources to level
+        db: Database session
+        current_user: Authenticated user
+
+    Returns:
+        LevelingResultResponse with proposed shifts
+
+    Raises:
+        HTTPException: 404 if program not found
+    """
+    program_repo = ProgramRepository(db)
+    program = await program_repo.get_by_id(program_id)
+
+    if not program:
+        raise HTTPException(status_code=404, detail="Program not found")
+
+    # Run leveling
+    service = ResourceLevelingService(db)
+    leveling_options = LevelingOptions(
+        preserve_critical_path=preserve_critical_path,
+        max_iterations=max_iterations,
+        target_resources=target_resources,
+        level_within_float=level_within_float,
+    )
+    result = await service.level_program(program_id, leveling_options)
+
+    return _convert_result_to_response(result)
+
+
+@router.post(
+    "/{program_id}/level/apply",
+    response_model=LevelingApplyResponse,
+    summary="Apply leveling shifts",
+)
+async def apply_leveling_shifts(
+    program_id: UUID,
+    request: LevelingApplyRequest,
+    db: DbSession,
+    current_user: CurrentUser,
+) -> LevelingApplyResponse:
+    """Apply selected activity shifts from leveling result.
+
+    Updates activity planned_start and planned_finish dates.
+    Only applies shifts for activity IDs in the request.
+
+    Args:
+        program_id: UUID of the program
+        request: List of activity IDs to apply shifts for
+        db: Database session
+        current_user: Authenticated user
+
+    Returns:
+        LevelingApplyResponse with counts and new finish date
+
+    Raises:
+        HTTPException: 404 if program not found
+    """
+    program_repo = ProgramRepository(db)
+    program = await program_repo.get_by_id(program_id)
+
+    if not program:
+        raise HTTPException(status_code=404, detail="Program not found")
+
+    # First run leveling to get the shifts
+    service = ResourceLevelingService(db)
+    result = await service.level_program(program_id)
+
+    # Filter shifts to only those requested
+    shifts_to_apply = {s.activity_id: s for s in result.shifts}
+    requested_ids = set(request.shifts)
+
+    applied_count = 0
+    skipped_count = 0
+    new_finish: date = result.original_project_finish
+
+    activity_repo = ActivityRepository(db)
+
+    for activity_id in requested_ids:
+        if activity_id in shifts_to_apply:
+            shift = shifts_to_apply[activity_id]
+            activity = await activity_repo.get_by_id(activity_id)
+
+            if activity:
+                activity.planned_start = shift.new_start
+                activity.planned_finish = shift.new_finish
+                await db.flush()
+                applied_count += 1
+
+                new_finish = max(new_finish, shift.new_finish)
+        else:
+            skipped_count += 1
+
+    await db.commit()
+
+    return LevelingApplyResponse(
+        applied_count=applied_count,
+        skipped_count=skipped_count,
+        new_project_finish=new_finish,
+    )

--- a/api/src/api/v1/router.py
+++ b/api/src/api/v1/router.py
@@ -12,6 +12,7 @@ from src.api.v1.endpoints import (
     import_export,
     jira_integration,
     jira_webhook,
+    leveling,
     management_reserve,
     overallocations,
     programs,
@@ -135,3 +136,6 @@ api_router.include_router(resources.assignments_router)
 
 # Week 15: Over-allocation detection
 api_router.include_router(overallocations.router)
+
+# Week 15: Resource leveling
+api_router.include_router(leveling.router)

--- a/api/src/schemas/leveling.py
+++ b/api/src/schemas/leveling.py
@@ -1,0 +1,102 @@
+"""Pydantic schemas for resource leveling API."""
+
+from __future__ import annotations
+
+from datetime import date  # noqa: TC003
+from uuid import UUID  # noqa: TC003
+
+from pydantic import BaseModel, Field
+
+
+class LevelingOptionsRequest(BaseModel):
+    """Request schema for leveling options.
+
+    Attributes:
+        preserve_critical_path: If True, never delay critical path activities
+        max_iterations: Maximum leveling iterations (1-1000)
+        target_resources: Specific resources to level (None = all)
+        level_within_float: If True, only delay within total float
+    """
+
+    preserve_critical_path: bool = True
+    max_iterations: int = Field(default=100, ge=1, le=1000)
+    target_resources: list[UUID] | None = None
+    level_within_float: bool = True
+
+
+class ActivityShiftResponse(BaseModel):
+    """Response schema for a single activity shift.
+
+    Attributes:
+        activity_id: UUID of the shifted activity
+        activity_code: Activity code for display
+        original_start: Original start date
+        original_finish: Original finish date
+        new_start: New start date after leveling
+        new_finish: New finish date after leveling
+        delay_days: Number of days delayed
+        reason: Explanation for the delay
+    """
+
+    activity_id: UUID
+    activity_code: str
+    original_start: date
+    original_finish: date
+    new_start: date
+    new_finish: date
+    delay_days: int
+    reason: str
+
+
+class LevelingResultResponse(BaseModel):
+    """Response schema for leveling result.
+
+    Attributes:
+        program_id: UUID of the leveled program
+        success: True if all over-allocations resolved
+        iterations_used: Number of leveling iterations performed
+        activities_shifted: Count of activities that were delayed
+        shifts: List of all activity shifts made
+        remaining_overallocations: Count of unresolved over-allocations
+        new_project_finish: Project finish date after leveling
+        original_project_finish: Project finish date before leveling
+        schedule_extension_days: Days added to project duration
+        warnings: List of warning messages
+    """
+
+    program_id: UUID
+    success: bool
+    iterations_used: int
+    activities_shifted: int
+    shifts: list[ActivityShiftResponse]
+    remaining_overallocations: int
+    new_project_finish: date
+    original_project_finish: date
+    schedule_extension_days: int
+    warnings: list[str] = Field(default_factory=list)
+
+    model_config = {"from_attributes": True}
+
+
+class LevelingApplyRequest(BaseModel):
+    """Request schema for applying leveling shifts.
+
+    Attributes:
+        shifts: List of activity IDs to apply shifts for
+    """
+
+    shifts: list[UUID]
+
+
+class LevelingApplyResponse(BaseModel):
+    """Response schema for apply operation.
+
+    Attributes:
+        applied_count: Number of activities updated
+        skipped_count: Number of activities skipped
+        new_project_finish: New project finish date after applying
+    """
+
+    applied_count: int
+    skipped_count: int
+    new_project_finish: date

--- a/api/tests/integration/test_leveling_api.py
+++ b/api/tests/integration/test_leveling_api.py
@@ -1,0 +1,362 @@
+"""Integration tests for resource leveling API endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from httpx import AsyncClient  # noqa: TC002
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture
+async def program_with_overallocation(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> dict:
+    """Create a program with activities that cause over-allocation."""
+    # Create program
+    program_response = await client.post(
+        "/api/v1/programs",
+        headers=auth_headers,
+        json={
+            "code": "LEVEL-TEST",
+            "name": "Leveling Test Program",
+            "start_date": "2024-01-01",
+            "end_date": "2024-12-31",
+        },
+    )
+    assert program_response.status_code == 201
+    program = program_response.json()
+    program_id = program["id"]
+
+    # Create WBS element
+    wbs_response = await client.post(
+        "/api/v1/wbs",
+        headers=auth_headers,
+        json={
+            "program_id": program_id,
+            "wbs_code": "1.0",
+            "name": "Project Root",
+        },
+    )
+    assert wbs_response.status_code == 201
+    wbs = wbs_response.json()
+    wbs_id = wbs["id"]
+
+    # Create resource
+    resource_response = await client.post(
+        "/api/v1/resources",
+        headers=auth_headers,
+        json={
+            "program_id": program_id,
+            "code": "ENG-001",
+            "name": "Engineer 1",
+            "resource_type": "labor",
+            "capacity_per_day": "8.0",
+            "cost_rate": "100.00",
+        },
+    )
+    assert resource_response.status_code == 201
+    resource = resource_response.json()
+    resource_id = resource["id"]
+
+    # Create two overlapping activities
+    activity1_response = await client.post(
+        "/api/v1/activities",
+        headers=auth_headers,
+        json={
+            "program_id": program_id,
+            "wbs_id": wbs_id,
+            "code": "ACT-001",
+            "name": "Activity 1",
+            "planned_start": "2024-01-15",
+            "planned_finish": "2024-01-19",
+            "duration": 5,
+        },
+    )
+    assert activity1_response.status_code == 201
+    activity1 = activity1_response.json()
+
+    activity2_response = await client.post(
+        "/api/v1/activities",
+        headers=auth_headers,
+        json={
+            "program_id": program_id,
+            "wbs_id": wbs_id,
+            "code": "ACT-002",
+            "name": "Activity 2",
+            "planned_start": "2024-01-15",
+            "planned_finish": "2024-01-19",
+            "duration": 5,
+        },
+    )
+    assert activity2_response.status_code == 201
+    activity2 = activity2_response.json()
+
+    # Assign same resource to both activities (causes over-allocation)
+    assign1_response = await client.post(
+        f"/api/v1/resources/{resource_id}/assignments",
+        headers=auth_headers,
+        json={
+            "activity_id": activity1["id"],
+            "resource_id": resource_id,
+            "units": "1.0",
+        },
+    )
+    assert assign1_response.status_code == 201
+
+    assign2_response = await client.post(
+        f"/api/v1/resources/{resource_id}/assignments",
+        headers=auth_headers,
+        json={
+            "activity_id": activity2["id"],
+            "resource_id": resource_id,
+            "units": "1.0",
+        },
+    )
+    assert assign2_response.status_code == 201
+
+    return {
+        "program_id": program_id,
+        "resource_id": resource_id,
+        "activity1_id": activity1["id"],
+        "activity2_id": activity2["id"],
+    }
+
+
+class TestLevelProgramEndpoint:
+    """Tests for POST /programs/{id}/level endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_level_program_success(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        program_with_overallocation: dict,
+    ) -> None:
+        """Should return leveling result for program."""
+        program_id = program_with_overallocation["program_id"]
+
+        response = await client.post(
+            f"/api/v1/programs/{program_id}/level",
+            headers=auth_headers,
+            json={
+                "preserve_critical_path": True,
+                "max_iterations": 100,
+                "level_within_float": False,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["program_id"] == program_id
+        assert "success" in data
+        assert "iterations_used" in data
+        assert "activities_shifted" in data
+        assert "shifts" in data
+        assert "remaining_overallocations" in data
+        assert "new_project_finish" in data
+        assert "original_project_finish" in data
+        assert "schedule_extension_days" in data
+        assert "warnings" in data
+
+    @pytest.mark.asyncio
+    async def test_level_program_with_options(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        program_with_overallocation: dict,
+    ) -> None:
+        """Should respect leveling options."""
+        program_id = program_with_overallocation["program_id"]
+        resource_id = program_with_overallocation["resource_id"]
+
+        response = await client.post(
+            f"/api/v1/programs/{program_id}/level",
+            headers=auth_headers,
+            json={
+                "preserve_critical_path": False,
+                "max_iterations": 50,
+                "target_resources": [resource_id],
+                "level_within_float": False,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should have processed the leveling
+        assert data["iterations_used"] <= 50
+
+    @pytest.mark.asyncio
+    async def test_level_program_not_found(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Should return 404 for nonexistent program."""
+        fake_id = "00000000-0000-0000-0000-000000000000"
+
+        response = await client.post(
+            f"/api/v1/programs/{fake_id}/level",
+            headers=auth_headers,
+            json={"preserve_critical_path": True},
+        )
+
+        assert response.status_code == 404
+        assert "Program not found" in response.json()["detail"]
+
+
+class TestPreviewLevelingEndpoint:
+    """Tests for GET /programs/{id}/level/preview endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_preview_leveling(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        program_with_overallocation: dict,
+    ) -> None:
+        """Should preview leveling via GET request."""
+        program_id = program_with_overallocation["program_id"]
+
+        response = await client.get(
+            f"/api/v1/programs/{program_id}/level/preview",
+            headers=auth_headers,
+            params={
+                "preserve_critical_path": True,
+                "level_within_float": False,
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["program_id"] == program_id
+        assert "shifts" in data
+
+    @pytest.mark.asyncio
+    async def test_preview_with_target_resources(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        program_with_overallocation: dict,
+    ) -> None:
+        """Should accept target_resources query param."""
+        program_id = program_with_overallocation["program_id"]
+        resource_id = program_with_overallocation["resource_id"]
+
+        response = await client.get(
+            f"/api/v1/programs/{program_id}/level/preview",
+            headers=auth_headers,
+            params={
+                "target_resources": [resource_id],
+            },
+        )
+
+        assert response.status_code == 200
+
+
+class TestApplyLevelingEndpoint:
+    """Tests for POST /programs/{id}/level/apply endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_apply_shifts(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        program_with_overallocation: dict,
+    ) -> None:
+        """Should apply selected shifts to activities."""
+        program_id = program_with_overallocation["program_id"]
+
+        # First run leveling to get shifts
+        level_response = await client.post(
+            f"/api/v1/programs/{program_id}/level",
+            headers=auth_headers,
+            json={"level_within_float": False},
+        )
+        assert level_response.status_code == 200
+        level_data = level_response.json()
+
+        # Get activity IDs that were shifted
+        shifted_ids = [s["activity_id"] for s in level_data["shifts"]]
+
+        if shifted_ids:
+            # Apply the shifts
+            apply_response = await client.post(
+                f"/api/v1/programs/{program_id}/level/apply",
+                headers=auth_headers,
+                json={"shifts": shifted_ids},
+            )
+
+            assert apply_response.status_code == 200
+            apply_data = apply_response.json()
+
+            # Note: applied_count may vary since apply re-runs leveling
+            assert "applied_count" in apply_data
+            assert "skipped_count" in apply_data
+            assert "new_project_finish" in apply_data
+
+    @pytest.mark.asyncio
+    async def test_apply_partial_shifts(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        program_with_overallocation: dict,
+    ) -> None:
+        """Should apply only selected shifts."""
+        program_id = program_with_overallocation["program_id"]
+
+        # First run leveling
+        level_response = await client.post(
+            f"/api/v1/programs/{program_id}/level",
+            headers=auth_headers,
+            json={"level_within_float": False},
+        )
+        level_data = level_response.json()
+
+        # Apply only first shift if any exist
+        shifted_ids = [s["activity_id"] for s in level_data["shifts"]]
+
+        if len(shifted_ids) >= 2:
+            # Apply only first one
+            apply_response = await client.post(
+                f"/api/v1/programs/{program_id}/level/apply",
+                headers=auth_headers,
+                json={"shifts": [shifted_ids[0]]},
+            )
+
+            assert apply_response.status_code == 200
+            apply_data = apply_response.json()
+
+            assert apply_data["applied_count"] == 1
+
+    @pytest.mark.asyncio
+    async def test_apply_nonexistent_shift(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        program_with_overallocation: dict,
+    ) -> None:
+        """Should skip nonexistent activity IDs."""
+        program_id = program_with_overallocation["program_id"]
+        fake_id = "00000000-0000-0000-0000-000000000000"
+
+        apply_response = await client.post(
+            f"/api/v1/programs/{program_id}/level/apply",
+            headers=auth_headers,
+            json={"shifts": [fake_id]},
+        )
+
+        assert apply_response.status_code == 200
+        apply_data = apply_response.json()
+
+        # Should skip the nonexistent shift
+        assert apply_data["skipped_count"] == 1
+        assert apply_data["applied_count"] == 0


### PR DESCRIPTION
## Summary

- Add `POST /programs/{id}/level` endpoint for running resource leveling
- Add `POST /programs/{id}/level/apply` endpoint for applying selected shifts
- Add `GET /programs/{id}/level/preview` endpoint for preview via GET
- Add `LevelingOptionsRequest` and `LevelingResultResponse` Pydantic schemas
- Add `ActivityShiftResponse`, `LevelingApplyRequest`, `LevelingApplyResponse` schemas

## Endpoints

### POST /programs/{program_id}/level
Runs resource leveling algorithm and returns proposed shifts without applying them.

Request body:
```json
{
  "preserve_critical_path": true,
  "max_iterations": 100,
  "target_resources": null,
  "level_within_float": true
}
```

### GET /programs/{program_id}/level/preview
Same as POST but as GET for easier testing. Options passed as query params.

### POST /programs/{program_id}/level/apply
Applies selected shifts from leveling result. Updates activity `planned_start` and `planned_finish` dates.

Request body:
```json
{
  "shifts": ["<activity-id-1>", "<activity-id-2>"]
}
```

## Test Plan

- [x] 8 integration tests passing
- [x] Ruff linting passes
- [x] Mypy type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)