### PR TITLE
feat(resource): add ResourceHistogramService for visualization

### DIFF
--- a/api/src/api/v1/endpoints/histogram.py
+++ b/api/src/api/v1/endpoints/histogram.py
@@ -1,0 +1,179 @@
+"""API endpoints for resource histograms."""
+
+from __future__ import annotations
+
+from datetime import date
+from uuid import UUID
+
+from fastapi import APIRouter, HTTPException, Query
+
+from src.core.deps import CurrentUser, DbSession
+from src.repositories.program import ProgramRepository
+from src.repositories.resource import ResourceRepository
+from src.schemas.histogram import (
+    HistogramDataPointResponse,
+    ProgramHistogramResponse,
+    ProgramHistogramSummaryResponse,
+    ResourceHistogramResponse,
+)
+from src.services.resource_histogram import ResourceHistogram, ResourceHistogramService
+
+router = APIRouter(tags=["Histograms"])
+
+
+def _convert_histogram_to_response(
+    histogram: ResourceHistogram,
+) -> ResourceHistogramResponse:
+    """Convert ResourceHistogram dataclass to response schema."""
+    data_points = [
+        HistogramDataPointResponse(
+            date=p.date,
+            available_hours=p.available_hours,
+            assigned_hours=p.assigned_hours,
+            utilization_percent=p.utilization_percent,
+            is_overallocated=p.is_overallocated,
+        )
+        for p in histogram.data_points
+    ]
+
+    return ResourceHistogramResponse(
+        resource_id=histogram.resource_id,
+        resource_code=histogram.resource_code,
+        resource_name=histogram.resource_name,
+        resource_type=histogram.resource_type,
+        start_date=histogram.start_date,
+        end_date=histogram.end_date,
+        data_points=data_points,
+        peak_utilization=histogram.peak_utilization,
+        peak_date=histogram.peak_date,
+        average_utilization=histogram.average_utilization,
+        overallocated_days=histogram.overallocated_days,
+        total_available_hours=histogram.total_available_hours,
+        total_assigned_hours=histogram.total_assigned_hours,
+    )
+
+
+@router.get(
+    "/resources/{resource_id}/histogram",
+    response_model=ResourceHistogramResponse,
+    summary="Get resource histogram",
+)
+async def get_resource_histogram(
+    resource_id: UUID,
+    db: DbSession,
+    current_user: CurrentUser,
+    start_date: date = Query(..., description="Start date for histogram"),
+    end_date: date = Query(..., description="End date for histogram"),
+    granularity: str = Query(
+        default="daily",
+        description="Granularity: 'daily' or 'weekly'",
+        pattern="^(daily|weekly)$",
+    ),
+) -> ResourceHistogramResponse:
+    """Get histogram data for a single resource.
+
+    Returns utilization data points for the specified date range.
+    Supports daily or weekly granularity.
+
+    Args:
+        resource_id: UUID of the resource
+        start_date: Start of histogram period
+        end_date: End of histogram period
+        granularity: "daily" or "weekly"
+        db: Database session
+        current_user: Authenticated user
+
+    Returns:
+        ResourceHistogramResponse with data points and statistics
+
+    Raises:
+        HTTPException: 404 if resource not found
+        HTTPException: 400 if date range invalid
+    """
+    if end_date < start_date:
+        raise HTTPException(status_code=400, detail="end_date must be after start_date")
+
+    # Verify resource exists and user has access
+    resource_repo = ResourceRepository(db)
+    resource = await resource_repo.get_by_id(resource_id)
+
+    if not resource:
+        raise HTTPException(status_code=404, detail="Resource not found")
+
+    # Generate histogram
+    service = ResourceHistogramService(db)
+    histogram = await service.get_resource_histogram(resource_id, start_date, end_date, granularity)
+
+    if not histogram:
+        raise HTTPException(status_code=404, detail="Resource not found")
+
+    return _convert_histogram_to_response(histogram)
+
+
+@router.get(
+    "/programs/{program_id}/histogram",
+    response_model=ProgramHistogramResponse,
+    summary="Get program histogram",
+)
+async def get_program_histogram(
+    program_id: UUID,
+    db: DbSession,
+    current_user: CurrentUser,
+    start_date: date | None = Query(default=None, description="Start date"),
+    end_date: date | None = Query(default=None, description="End date"),
+    resource_ids: list[UUID] | None = Query(
+        default=None, description="Filter to specific resources"
+    ),
+) -> ProgramHistogramResponse:
+    """Get histogram data for all resources in a program.
+
+    Returns utilization data for all active resources in the program.
+    Optionally filter to specific resources.
+
+    Args:
+        program_id: UUID of the program
+        start_date: Start of period (defaults to program start)
+        end_date: End of period (defaults to program end)
+        resource_ids: Optional filter for specific resources
+        db: Database session
+        current_user: Authenticated user
+
+    Returns:
+        ProgramHistogramResponse with summary and resource histograms
+
+    Raises:
+        HTTPException: 404 if program not found
+        HTTPException: 400 if date range invalid
+    """
+    if start_date and end_date and end_date < start_date:
+        raise HTTPException(status_code=400, detail="end_date must be after start_date")
+
+    # Verify program exists
+    program_repo = ProgramRepository(db)
+    program = await program_repo.get_by_id(program_id)
+
+    if not program:
+        raise HTTPException(status_code=404, detail="Program not found")
+
+    # Generate histograms
+    service = ResourceHistogramService(db)
+    summary, histograms = await service.get_program_histogram(
+        program_id, start_date, end_date, resource_ids
+    )
+
+    # Convert to response schemas
+    histogram_responses = [_convert_histogram_to_response(h) for h in histograms]
+
+    summary_response = ProgramHistogramSummaryResponse(
+        program_id=summary.program_id,
+        start_date=summary.start_date,
+        end_date=summary.end_date,
+        resource_count=summary.resource_count,
+        total_overallocated_days=summary.total_overallocated_days,
+        resources_with_overallocation=summary.resources_with_overallocation,
+    )
+
+    return ProgramHistogramResponse(
+        summary=summary_response,
+        histograms=histogram_responses,
+    )

--- a/api/src/api/v1/router.py
+++ b/api/src/api/v1/router.py
@@ -9,6 +9,7 @@ from src.api.v1.endpoints import (
     baselines,
     dependencies,
     evms,
+    histogram,
     import_export,
     jira_integration,
     jira_webhook,
@@ -139,3 +140,6 @@ api_router.include_router(overallocations.router)
 
 # Week 15: Resource leveling
 api_router.include_router(leveling.router)
+
+# Week 15: Resource histograms
+api_router.include_router(histogram.router)

--- a/api/src/schemas/histogram.py
+++ b/api/src/schemas/histogram.py
@@ -1,0 +1,99 @@
+"""Pydantic schemas for resource histogram API."""
+
+from __future__ import annotations
+
+from datetime import date  # noqa: TC003
+from decimal import Decimal  # noqa: TC003
+from uuid import UUID  # noqa: TC003
+
+from pydantic import BaseModel, Field
+
+from src.models.enums import ResourceType  # noqa: TC001
+
+
+class HistogramDataPointResponse(BaseModel):
+    """Response schema for a single histogram data point.
+
+    Attributes:
+        date: The date for this data point
+        available_hours: Hours available on this day/week
+        assigned_hours: Hours assigned on this day/week
+        utilization_percent: Utilization as percentage (0-100+)
+        is_overallocated: True if assigned > available
+    """
+
+    date: date
+    available_hours: Decimal
+    assigned_hours: Decimal
+    utilization_percent: Decimal
+    is_overallocated: bool
+
+
+class ResourceHistogramResponse(BaseModel):
+    """Response schema for single resource histogram.
+
+    Attributes:
+        resource_id: UUID of the resource
+        resource_code: Resource code for display
+        resource_name: Resource name for display
+        resource_type: Type of resource
+        start_date: Start of histogram period
+        end_date: End of histogram period
+        data_points: List of data points
+        peak_utilization: Maximum utilization percentage
+        peak_date: Date of peak utilization
+        average_utilization: Average utilization over period
+        overallocated_days: Number of days with over-allocation
+        total_available_hours: Sum of available hours
+        total_assigned_hours: Sum of assigned hours
+    """
+
+    resource_id: UUID
+    resource_code: str
+    resource_name: str
+    resource_type: ResourceType
+    start_date: date
+    end_date: date
+    data_points: list[HistogramDataPointResponse]
+    peak_utilization: Decimal
+    peak_date: date | None
+    average_utilization: Decimal
+    overallocated_days: int
+    total_available_hours: Decimal
+    total_assigned_hours: Decimal
+
+    model_config = {"from_attributes": True}
+
+
+class ProgramHistogramSummaryResponse(BaseModel):
+    """Response schema for program histogram summary.
+
+    Attributes:
+        program_id: UUID of the program
+        start_date: Start of analysis period
+        end_date: End of analysis period
+        resource_count: Number of resources in histogram
+        total_overallocated_days: Sum of overallocated days across resources
+        resources_with_overallocation: Count of resources with over-allocation
+    """
+
+    program_id: UUID
+    start_date: date
+    end_date: date
+    resource_count: int
+    total_overallocated_days: int
+    resources_with_overallocation: int
+
+    model_config = {"from_attributes": True}
+
+
+class ProgramHistogramResponse(BaseModel):
+    """Response schema for program-wide histogram.
+
+    Attributes:
+        summary: Summary statistics for the program
+        histograms: List of resource histograms
+    """
+
+    summary: ProgramHistogramSummaryResponse
+    histograms: list[ResourceHistogramResponse] = Field(default_factory=list)

--- a/api/src/services/resource_histogram.py
+++ b/api/src/services/resource_histogram.py
@@ -1,0 +1,419 @@
+"""Resource histogram service for visualization data.
+
+Provides histogram data showing resource loading over time for capacity planning.
+Supports single-resource and program-wide histograms with daily/weekly granularity.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import date, timedelta
+from decimal import Decimal
+from typing import TYPE_CHECKING
+
+from src.repositories.program import ProgramRepository
+from src.repositories.resource import ResourceRepository
+from src.services.resource_loading import ResourceLoadingService
+
+if TYPE_CHECKING:
+    from uuid import UUID
+
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+    from src.models.enums import ResourceType
+    from src.services.cache_service import CacheService
+
+
+@dataclass
+class HistogramDataPoint:
+    """A single data point in the resource histogram.
+
+    Attributes:
+        date: The date for this data point
+        available_hours: Hours available on this day
+        assigned_hours: Hours assigned on this day
+        utilization_percent: Utilization as percentage (0-100+)
+        is_overallocated: True if assigned > available
+    """
+
+    date: date
+    available_hours: Decimal
+    assigned_hours: Decimal
+    utilization_percent: Decimal
+    is_overallocated: bool
+
+
+@dataclass
+class ResourceHistogram:
+    """Complete histogram data for a single resource.
+
+    Attributes:
+        resource_id: UUID of the resource
+        resource_code: Resource code for display
+        resource_name: Resource name for display
+        resource_type: Type of resource (labor, equipment, etc.)
+        start_date: Start of histogram period
+        end_date: End of histogram period
+        data_points: List of data points in the histogram
+        peak_utilization: Maximum utilization percentage
+        peak_date: Date of peak utilization
+        average_utilization: Average utilization over period
+        overallocated_days: Number of days with over-allocation
+        total_available_hours: Sum of available hours in period
+        total_assigned_hours: Sum of assigned hours in period
+    """
+
+    resource_id: UUID
+    resource_code: str
+    resource_name: str
+    resource_type: ResourceType
+    start_date: date
+    end_date: date
+    data_points: list[HistogramDataPoint] = field(default_factory=list)
+    peak_utilization: Decimal = Decimal("0")
+    peak_date: date | None = None
+    average_utilization: Decimal = Decimal("0")
+    overallocated_days: int = 0
+    total_available_hours: Decimal = Decimal("0")
+    total_assigned_hours: Decimal = Decimal("0")
+
+
+@dataclass
+class ProgramHistogramSummary:
+    """Summary statistics for program-wide histogram.
+
+    Attributes:
+        program_id: UUID of the program
+        start_date: Start of analysis period
+        end_date: End of analysis period
+        resource_count: Number of resources in histogram
+        total_overallocated_days: Sum of overallocated days across all resources
+        resources_with_overallocation: Count of resources with any over-allocation
+    """
+
+    program_id: UUID
+    start_date: date
+    end_date: date
+    resource_count: int
+    total_overallocated_days: int
+    resources_with_overallocation: int
+
+
+class ResourceHistogramService:
+    """Service for generating resource histogram data.
+
+    Provides histogram visualization data for capacity planning and
+    resource management. Supports both single-resource detailed views
+    and program-wide summary views.
+
+    Example usage:
+        service = ResourceHistogramService(session)
+        histogram = await service.get_resource_histogram(
+            resource_id,
+            date(2024, 1, 1),
+            date(2024, 3, 31),
+            granularity="weekly"
+        )
+        for point in histogram.data_points:
+            print(f"{point.date}: {point.utilization_percent}%")
+    """
+
+    def __init__(
+        self,
+        session: AsyncSession,
+        cache: CacheService | None = None,
+    ) -> None:
+        """Initialize ResourceHistogramService.
+
+        Args:
+            session: Database session for queries
+            cache: Optional cache service
+        """
+        self.session = session
+        self.cache = cache
+        self._resource_repo = ResourceRepository(session)
+        self._program_repo = ProgramRepository(session)
+        self._loading_service = ResourceLoadingService(session, cache)
+
+    async def get_resource_histogram(
+        self,
+        resource_id: UUID,
+        start_date: date,
+        end_date: date,
+        granularity: str = "daily",
+    ) -> ResourceHistogram | None:
+        """Generate histogram data for a single resource.
+
+        Args:
+            resource_id: UUID of the resource
+            start_date: Start of histogram period
+            end_date: End of histogram period
+            granularity: "daily" or "weekly"
+
+        Returns:
+            ResourceHistogram with data points, or None if resource not found
+        """
+        resource = await self._resource_repo.get_by_id(resource_id)
+        if not resource:
+            return None
+
+        # Get daily loading data
+        loading = await self._loading_service.calculate_daily_loading(
+            resource_id, start_date, end_date
+        )
+
+        # Convert to data points
+        data_points: list[HistogramDataPoint] = []
+        current = start_date
+        while current <= end_date:
+            if current in loading:
+                day_loading = loading[current]
+                available = day_loading.available_hours
+                assigned = day_loading.assigned_hours
+                utilization = (
+                    (assigned / available * Decimal("100")) if available > 0 else Decimal("0")
+                )
+                is_over = day_loading.is_overallocated
+            else:
+                # No loading data - use resource capacity
+                available = resource.capacity_per_day
+                assigned = Decimal("0")
+                utilization = Decimal("0")
+                is_over = False
+
+            data_points.append(
+                HistogramDataPoint(
+                    date=current,
+                    available_hours=available,
+                    assigned_hours=assigned,
+                    utilization_percent=utilization,
+                    is_overallocated=is_over,
+                )
+            )
+            current += timedelta(days=1)
+
+        # Aggregate if weekly
+        if granularity == "weekly":
+            data_points = self._aggregate_to_weekly(data_points)
+
+        # Calculate statistics
+        stats = self._calculate_statistics(data_points)
+
+        return ResourceHistogram(
+            resource_id=resource.id,
+            resource_code=resource.code,
+            resource_name=resource.name,
+            resource_type=resource.resource_type,
+            start_date=start_date,
+            end_date=end_date,
+            data_points=data_points,
+            peak_utilization=stats["peak_utilization"],
+            peak_date=stats["peak_date"],
+            average_utilization=stats["average_utilization"],
+            overallocated_days=stats["overallocated_days"],
+            total_available_hours=stats["total_available_hours"],
+            total_assigned_hours=stats["total_assigned_hours"],
+        )
+
+    async def get_program_histogram(
+        self,
+        program_id: UUID,
+        start_date: date | None = None,
+        end_date: date | None = None,
+        resource_ids: list[UUID] | None = None,
+    ) -> tuple[ProgramHistogramSummary, list[ResourceHistogram]]:
+        """Generate histogram data for all resources in a program.
+
+        Args:
+            program_id: UUID of the program
+            start_date: Start of period (defaults to program start)
+            end_date: End of period (defaults to program end)
+            resource_ids: Optional filter for specific resources
+
+        Returns:
+            Tuple of (ProgramHistogramSummary, list of ResourceHistogram)
+        """
+        program = await self._program_repo.get_by_id(program_id)
+
+        if not program:
+            return (
+                ProgramHistogramSummary(
+                    program_id=program_id,
+                    start_date=start_date or date.today(),
+                    end_date=end_date or date.today(),
+                    resource_count=0,
+                    total_overallocated_days=0,
+                    resources_with_overallocation=0,
+                ),
+                [],
+            )
+
+        # Use program dates if not specified
+        analysis_start = start_date or program.start_date
+        analysis_end = end_date or program.end_date
+
+        # Get resources
+        resources, _ = await self._resource_repo.get_by_program(
+            program_id, is_active=True, skip=0, limit=10000
+        )
+
+        # Filter if specific resources requested
+        if resource_ids:
+            resource_id_set = set(resource_ids)
+            resources = [r for r in resources if r.id in resource_id_set]
+
+        # Generate histograms for each resource
+        histograms: list[ResourceHistogram] = []
+        total_overallocated_days = 0
+        resources_with_overallocation = 0
+
+        for resource in resources:
+            histogram = await self.get_resource_histogram(
+                resource.id, analysis_start, analysis_end, granularity="daily"
+            )
+            if histogram:
+                histograms.append(histogram)
+                total_overallocated_days += histogram.overallocated_days
+                if histogram.overallocated_days > 0:
+                    resources_with_overallocation += 1
+
+        summary = ProgramHistogramSummary(
+            program_id=program_id,
+            start_date=analysis_start,
+            end_date=analysis_end,
+            resource_count=len(histograms),
+            total_overallocated_days=total_overallocated_days,
+            resources_with_overallocation=resources_with_overallocation,
+        )
+
+        return summary, histograms
+
+    def _aggregate_to_weekly(
+        self,
+        daily_data: list[HistogramDataPoint],
+    ) -> list[HistogramDataPoint]:
+        """Aggregate daily data points to weekly.
+
+        Sums hours and calculates average utilization for each week.
+        Week starts on Monday.
+
+        Args:
+            daily_data: List of daily data points
+
+        Returns:
+            List of weekly aggregated data points
+        """
+        if not daily_data:
+            return []
+
+        weekly_data: list[HistogramDataPoint] = []
+        week_points: list[HistogramDataPoint] = []
+        current_week_start: date | None = None
+
+        for point in daily_data:
+            # Get Monday of this week
+            week_start = point.date - timedelta(days=point.date.weekday())
+
+            if current_week_start is None:
+                current_week_start = week_start
+
+            if week_start != current_week_start:
+                # Aggregate previous week
+                if week_points:
+                    weekly_data.append(self._aggregate_week(week_points))
+                week_points = []
+                current_week_start = week_start
+
+            week_points.append(point)
+
+        # Don't forget the last week
+        if week_points:
+            weekly_data.append(self._aggregate_week(week_points))
+
+        return weekly_data
+
+    def _aggregate_week(
+        self,
+        points: list[HistogramDataPoint],
+    ) -> HistogramDataPoint:
+        """Aggregate a list of daily points into one weekly point.
+
+        Args:
+            points: Daily data points for one week
+
+        Returns:
+            Single aggregated data point for the week
+        """
+        total_available = sum((p.available_hours for p in points), Decimal("0"))
+        total_assigned = sum((p.assigned_hours for p in points), Decimal("0"))
+        is_over = any(p.is_overallocated for p in points)
+
+        utilization = (
+            (total_assigned / total_available * Decimal("100"))
+            if total_available > 0
+            else Decimal("0")
+        )
+
+        # Use Monday of the week as the date
+        week_start = points[0].date - timedelta(days=points[0].date.weekday())
+
+        return HistogramDataPoint(
+            date=week_start,
+            available_hours=total_available,
+            assigned_hours=total_assigned,
+            utilization_percent=utilization,
+            is_overallocated=is_over,
+        )
+
+    def _calculate_statistics(
+        self,
+        data_points: list[HistogramDataPoint],
+    ) -> dict:  # type: ignore[type-arg]
+        """Calculate summary statistics for histogram data.
+
+        Args:
+            data_points: List of data points
+
+        Returns:
+            Dictionary with peak_utilization, peak_date, average_utilization,
+            overallocated_days, total_available_hours, total_assigned_hours
+        """
+        if not data_points:
+            return {
+                "peak_utilization": Decimal("0"),
+                "peak_date": None,
+                "average_utilization": Decimal("0"),
+                "overallocated_days": 0,
+                "total_available_hours": Decimal("0"),
+                "total_assigned_hours": Decimal("0"),
+            }
+
+        peak_utilization = Decimal("0")
+        peak_date: date | None = None
+        total_utilization = Decimal("0")
+        overallocated_days = 0
+        total_available = Decimal("0")
+        total_assigned = Decimal("0")
+
+        for point in data_points:
+            if point.utilization_percent > peak_utilization:
+                peak_utilization = point.utilization_percent
+                peak_date = point.date
+
+            total_utilization += point.utilization_percent
+            total_available += point.available_hours
+            total_assigned += point.assigned_hours
+
+            if point.is_overallocated:
+                overallocated_days += 1
+
+        average_utilization = total_utilization / len(data_points)
+
+        return {
+            "peak_utilization": peak_utilization,
+            "peak_date": peak_date,
+            "average_utilization": average_utilization,
+            "overallocated_days": overallocated_days,
+            "total_available_hours": total_available,
+            "total_assigned_hours": total_assigned,
+        }

--- a/api/tests/integration/test_histogram_api.py
+++ b/api/tests/integration/test_histogram_api.py
@@ -1,0 +1,314 @@
+"""Integration tests for resource histogram API endpoints."""
+
+from __future__ import annotations
+
+from typing import TYPE_CHECKING
+
+import pytest
+from httpx import AsyncClient  # noqa: TC002
+
+if TYPE_CHECKING:
+    from sqlalchemy.ext.asyncio import AsyncSession
+
+
+@pytest.fixture
+async def program_with_resources(
+    client: AsyncClient,
+    auth_headers: dict[str, str],
+    db_session: AsyncSession,
+) -> dict:
+    """Create a program with resources and activities for histogram testing."""
+    # Create program
+    program_response = await client.post(
+        "/api/v1/programs",
+        headers=auth_headers,
+        json={
+            "code": "HIST-TEST",
+            "name": "Histogram Test Program",
+            "start_date": "2024-01-01",
+            "end_date": "2024-12-31",
+        },
+    )
+    assert program_response.status_code == 201
+    program = program_response.json()
+    program_id = program["id"]
+
+    # Create WBS element
+    wbs_response = await client.post(
+        "/api/v1/wbs",
+        headers=auth_headers,
+        json={
+            "program_id": program_id,
+            "wbs_code": "1.0",
+            "name": "Project Root",
+        },
+    )
+    assert wbs_response.status_code == 201
+    wbs = wbs_response.json()
+    wbs_id = wbs["id"]
+
+    # Create resources
+    resource1_response = await client.post(
+        "/api/v1/resources",
+        headers=auth_headers,
+        json={
+            "program_id": program_id,
+            "code": "ENG-001",
+            "name": "Engineer 1",
+            "resource_type": "labor",
+            "capacity_per_day": "8.0",
+            "cost_rate": "100.00",
+        },
+    )
+    assert resource1_response.status_code == 201
+    resource1 = resource1_response.json()
+
+    resource2_response = await client.post(
+        "/api/v1/resources",
+        headers=auth_headers,
+        json={
+            "program_id": program_id,
+            "code": "ENG-002",
+            "name": "Engineer 2",
+            "resource_type": "labor",
+            "capacity_per_day": "8.0",
+            "cost_rate": "100.00",
+        },
+    )
+    assert resource2_response.status_code == 201
+    resource2 = resource2_response.json()
+
+    # Create activity
+    activity_response = await client.post(
+        "/api/v1/activities",
+        headers=auth_headers,
+        json={
+            "program_id": program_id,
+            "wbs_id": wbs_id,
+            "code": "ACT-001",
+            "name": "Test Activity",
+            "planned_start": "2024-01-15",
+            "planned_finish": "2024-01-19",
+            "duration": 5,
+        },
+    )
+    assert activity_response.status_code == 201
+    activity = activity_response.json()
+
+    # Create assignment
+    assign_response = await client.post(
+        f"/api/v1/resources/{resource1['id']}/assignments",
+        headers=auth_headers,
+        json={
+            "activity_id": activity["id"],
+            "resource_id": resource1["id"],
+            "units": "1.0",
+        },
+    )
+    assert assign_response.status_code == 201
+
+    return {
+        "program_id": program_id,
+        "resource1_id": resource1["id"],
+        "resource2_id": resource2["id"],
+        "activity_id": activity["id"],
+    }
+
+
+class TestGetResourceHistogram:
+    """Tests for GET /resources/{id}/histogram endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_resource_histogram(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        program_with_resources: dict,
+    ) -> None:
+        """Should return histogram data for resource."""
+        resource_id = program_with_resources["resource1_id"]
+
+        response = await client.get(
+            f"/api/v1/resources/{resource_id}/histogram",
+            headers=auth_headers,
+            params={
+                "start_date": "2024-01-15",
+                "end_date": "2024-01-19",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["resource_id"] == resource_id
+        assert data["resource_code"] == "ENG-001"
+        assert "data_points" in data
+        assert len(data["data_points"]) == 5
+        assert "peak_utilization" in data
+        assert "average_utilization" in data
+        assert "overallocated_days" in data
+
+    @pytest.mark.asyncio
+    async def test_get_resource_histogram_weekly(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        program_with_resources: dict,
+    ) -> None:
+        """Should return weekly aggregated histogram."""
+        resource_id = program_with_resources["resource1_id"]
+
+        response = await client.get(
+            f"/api/v1/resources/{resource_id}/histogram",
+            headers=auth_headers,
+            params={
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+                "granularity": "weekly",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Weekly should have fewer data points than daily
+        assert len(data["data_points"]) < 31
+
+    @pytest.mark.asyncio
+    async def test_resource_not_found(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Should return 404 for nonexistent resource."""
+        fake_id = "00000000-0000-0000-0000-000000000000"
+
+        response = await client.get(
+            f"/api/v1/resources/{fake_id}/histogram",
+            headers=auth_headers,
+            params={
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+            },
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_invalid_date_range(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        program_with_resources: dict,
+    ) -> None:
+        """Should return 400 for invalid date range."""
+        resource_id = program_with_resources["resource1_id"]
+
+        response = await client.get(
+            f"/api/v1/resources/{resource_id}/histogram",
+            headers=auth_headers,
+            params={
+                "start_date": "2024-01-31",
+                "end_date": "2024-01-01",  # End before start
+            },
+        )
+
+        assert response.status_code == 400
+
+
+class TestGetProgramHistogram:
+    """Tests for GET /programs/{id}/histogram endpoint."""
+
+    @pytest.mark.asyncio
+    async def test_get_program_histogram(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        program_with_resources: dict,
+    ) -> None:
+        """Should return histogram data for all program resources."""
+        program_id = program_with_resources["program_id"]
+
+        response = await client.get(
+            f"/api/v1/programs/{program_id}/histogram",
+            headers=auth_headers,
+            params={
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert "summary" in data
+        assert "histograms" in data
+        assert data["summary"]["program_id"] == program_id
+        assert data["summary"]["resource_count"] == 2
+        assert len(data["histograms"]) == 2
+
+    @pytest.mark.asyncio
+    async def test_program_histogram_with_filter(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        program_with_resources: dict,
+    ) -> None:
+        """Should filter to specific resources."""
+        program_id = program_with_resources["program_id"]
+        resource1_id = program_with_resources["resource1_id"]
+
+        response = await client.get(
+            f"/api/v1/programs/{program_id}/histogram",
+            headers=auth_headers,
+            params={
+                "start_date": "2024-01-01",
+                "end_date": "2024-01-31",
+                "resource_ids": [resource1_id],
+            },
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        assert data["summary"]["resource_count"] == 1
+        assert len(data["histograms"]) == 1
+        assert data["histograms"][0]["resource_id"] == resource1_id
+
+    @pytest.mark.asyncio
+    async def test_program_not_found(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+    ) -> None:
+        """Should return 404 for nonexistent program."""
+        fake_id = "00000000-0000-0000-0000-000000000000"
+
+        response = await client.get(
+            f"/api/v1/programs/{fake_id}/histogram",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 404
+
+    @pytest.mark.asyncio
+    async def test_program_histogram_default_dates(
+        self,
+        client: AsyncClient,
+        auth_headers: dict[str, str],
+        program_with_resources: dict,
+    ) -> None:
+        """Should use program dates when not specified."""
+        program_id = program_with_resources["program_id"]
+
+        response = await client.get(
+            f"/api/v1/programs/{program_id}/histogram",
+            headers=auth_headers,
+        )
+
+        assert response.status_code == 200
+        data = response.json()
+
+        # Should use program's date range
+        assert data["summary"]["start_date"] == "2024-01-01"
+        assert data["summary"]["end_date"] == "2024-12-31"

--- a/api/tests/unit/test_histogram.py
+++ b/api/tests/unit/test_histogram.py
@@ -1,0 +1,478 @@
+"""Unit tests for ResourceHistogramService.
+
+Tests histogram generation, aggregation, and statistics calculation.
+"""
+
+from __future__ import annotations
+
+from datetime import date, timedelta
+from decimal import Decimal
+from unittest.mock import AsyncMock, MagicMock
+from uuid import uuid4
+
+import pytest
+
+from src.models.enums import ResourceType
+from src.services.resource_histogram import (
+    HistogramDataPoint,
+    ProgramHistogramSummary,
+    ResourceHistogram,
+    ResourceHistogramService,
+)
+
+
+class TestHistogramDataPoint:
+    """Tests for HistogramDataPoint dataclass."""
+
+    def test_create_data_point(self) -> None:
+        """Should create data point with all fields."""
+        point = HistogramDataPoint(
+            date=date(2024, 1, 15),
+            available_hours=Decimal("8.0"),
+            assigned_hours=Decimal("6.0"),
+            utilization_percent=Decimal("75.0"),
+            is_overallocated=False,
+        )
+
+        assert point.date == date(2024, 1, 15)
+        assert point.available_hours == Decimal("8.0")
+        assert point.assigned_hours == Decimal("6.0")
+        assert point.utilization_percent == Decimal("75.0")
+        assert point.is_overallocated is False
+
+    def test_overallocated_point(self) -> None:
+        """Should represent over-allocated day."""
+        point = HistogramDataPoint(
+            date=date(2024, 1, 15),
+            available_hours=Decimal("8.0"),
+            assigned_hours=Decimal("12.0"),
+            utilization_percent=Decimal("150.0"),
+            is_overallocated=True,
+        )
+
+        assert point.is_overallocated is True
+        assert point.utilization_percent > Decimal("100")
+
+
+class TestResourceHistogram:
+    """Tests for ResourceHistogram dataclass."""
+
+    def test_create_histogram(self) -> None:
+        """Should create histogram with all fields."""
+        resource_id = uuid4()
+        histogram = ResourceHistogram(
+            resource_id=resource_id,
+            resource_code="ENG-001",
+            resource_name="Engineer 1",
+            resource_type=ResourceType.LABOR,
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 1, 31),
+            data_points=[],
+            peak_utilization=Decimal("85.0"),
+            peak_date=date(2024, 1, 15),
+            average_utilization=Decimal("60.0"),
+            overallocated_days=2,
+            total_available_hours=Decimal("160.0"),
+            total_assigned_hours=Decimal("96.0"),
+        )
+
+        assert histogram.resource_id == resource_id
+        assert histogram.resource_code == "ENG-001"
+        assert histogram.peak_utilization == Decimal("85.0")
+        assert histogram.overallocated_days == 2
+
+
+class TestProgramHistogramSummary:
+    """Tests for ProgramHistogramSummary dataclass."""
+
+    def test_create_summary(self) -> None:
+        """Should create program summary."""
+        program_id = uuid4()
+        summary = ProgramHistogramSummary(
+            program_id=program_id,
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 3, 31),
+            resource_count=5,
+            total_overallocated_days=12,
+            resources_with_overallocation=2,
+        )
+
+        assert summary.program_id == program_id
+        assert summary.resource_count == 5
+        assert summary.total_overallocated_days == 12
+        assert summary.resources_with_overallocation == 2
+
+
+class TestGetResourceHistogram:
+    """Tests for get_resource_histogram method."""
+
+    @pytest.mark.asyncio
+    async def test_single_resource_histogram(self) -> None:
+        """Should generate histogram for single resource."""
+        mock_session = MagicMock()
+        service = ResourceHistogramService(mock_session)
+
+        resource_id = uuid4()
+
+        # Mock resource
+        mock_resource = MagicMock()
+        mock_resource.id = resource_id
+        mock_resource.code = "ENG-001"
+        mock_resource.name = "Engineer 1"
+        mock_resource.resource_type = ResourceType.LABOR
+        mock_resource.capacity_per_day = Decimal("8.0")
+        service._resource_repo = MagicMock()
+        service._resource_repo.get_by_id = AsyncMock(return_value=mock_resource)
+
+        # Mock loading service - 5 days of data
+        mock_loading = {}
+        for i in range(5):
+            day = date(2024, 1, 15) + timedelta(days=i)
+            mock_day = MagicMock()
+            mock_day.available_hours = Decimal("8.0")
+            mock_day.assigned_hours = Decimal("6.0")
+            mock_day.is_overallocated = False
+            mock_loading[day] = mock_day
+
+        service._loading_service = MagicMock()
+        service._loading_service.calculate_daily_loading = AsyncMock(return_value=mock_loading)
+
+        # Act
+        result = await service.get_resource_histogram(
+            resource_id, date(2024, 1, 15), date(2024, 1, 19)
+        )
+
+        # Assert
+        assert result is not None
+        assert result.resource_id == resource_id
+        assert result.resource_code == "ENG-001"
+        assert len(result.data_points) == 5
+        assert result.average_utilization == Decimal("75.0")
+
+    @pytest.mark.asyncio
+    async def test_histogram_with_overallocation(self) -> None:
+        """Should correctly identify over-allocated days."""
+        mock_session = MagicMock()
+        service = ResourceHistogramService(mock_session)
+
+        resource_id = uuid4()
+
+        # Mock resource
+        mock_resource = MagicMock()
+        mock_resource.id = resource_id
+        mock_resource.code = "ENG-001"
+        mock_resource.name = "Engineer 1"
+        mock_resource.resource_type = ResourceType.LABOR
+        mock_resource.capacity_per_day = Decimal("8.0")
+        service._resource_repo = MagicMock()
+        service._resource_repo.get_by_id = AsyncMock(return_value=mock_resource)
+
+        # Mock loading with 2 overallocated days
+        mock_loading = {}
+        for i in range(5):
+            day = date(2024, 1, 15) + timedelta(days=i)
+            mock_day = MagicMock()
+            mock_day.available_hours = Decimal("8.0")
+            if i < 2:  # First 2 days overallocated
+                mock_day.assigned_hours = Decimal("12.0")
+                mock_day.is_overallocated = True
+            else:
+                mock_day.assigned_hours = Decimal("6.0")
+                mock_day.is_overallocated = False
+            mock_loading[day] = mock_day
+
+        service._loading_service = MagicMock()
+        service._loading_service.calculate_daily_loading = AsyncMock(return_value=mock_loading)
+
+        # Act
+        result = await service.get_resource_histogram(
+            resource_id, date(2024, 1, 15), date(2024, 1, 19)
+        )
+
+        # Assert
+        assert result is not None
+        assert result.overallocated_days == 2
+        assert result.peak_utilization == Decimal("150.0")
+
+    @pytest.mark.asyncio
+    async def test_resource_not_found(self) -> None:
+        """Should return None if resource not found."""
+        mock_session = MagicMock()
+        service = ResourceHistogramService(mock_session)
+
+        service._resource_repo = MagicMock()
+        service._resource_repo.get_by_id = AsyncMock(return_value=None)
+
+        result = await service.get_resource_histogram(uuid4(), date(2024, 1, 1), date(2024, 1, 31))
+
+        assert result is None
+
+
+class TestWeeklyAggregation:
+    """Tests for weekly aggregation."""
+
+    def test_aggregate_to_weekly(self) -> None:
+        """Should aggregate daily data to weekly."""
+        mock_session = MagicMock()
+        service = ResourceHistogramService(mock_session)
+
+        # Create 14 days of data (2 full weeks starting Monday)
+        daily_data = []
+        # Start from Monday 2024-01-15
+        for i in range(14):
+            day = date(2024, 1, 15) + timedelta(days=i)
+            daily_data.append(
+                HistogramDataPoint(
+                    date=day,
+                    available_hours=Decimal("8.0"),
+                    assigned_hours=Decimal("6.0"),
+                    utilization_percent=Decimal("75.0"),
+                    is_overallocated=False,
+                )
+            )
+
+        # Act
+        weekly_data = service._aggregate_to_weekly(daily_data)
+
+        # Assert
+        assert len(weekly_data) == 2
+        # Each week should have summed hours
+        assert weekly_data[0].available_hours == Decimal("56.0")  # 7 * 8
+        assert weekly_data[0].assigned_hours == Decimal("42.0")  # 7 * 6
+
+    def test_aggregate_partial_week(self) -> None:
+        """Should handle partial weeks."""
+        mock_session = MagicMock()
+        service = ResourceHistogramService(mock_session)
+
+        # Create 10 days (1 full week + 3 days)
+        daily_data = []
+        for i in range(10):
+            day = date(2024, 1, 15) + timedelta(days=i)
+            daily_data.append(
+                HistogramDataPoint(
+                    date=day,
+                    available_hours=Decimal("8.0"),
+                    assigned_hours=Decimal("6.0"),
+                    utilization_percent=Decimal("75.0"),
+                    is_overallocated=False,
+                )
+            )
+
+        # Act
+        weekly_data = service._aggregate_to_weekly(daily_data)
+
+        # Assert
+        assert len(weekly_data) == 2
+
+    def test_aggregate_with_overallocation(self) -> None:
+        """Should mark week as overallocated if any day is."""
+        mock_session = MagicMock()
+        service = ResourceHistogramService(mock_session)
+
+        # Create 7 days with 1 overallocated
+        daily_data = []
+        for i in range(7):
+            day = date(2024, 1, 15) + timedelta(days=i)
+            is_over = i == 3  # Only day 4 is overallocated
+            daily_data.append(
+                HistogramDataPoint(
+                    date=day,
+                    available_hours=Decimal("8.0"),
+                    assigned_hours=Decimal("10.0") if is_over else Decimal("6.0"),
+                    utilization_percent=Decimal("125.0") if is_over else Decimal("75.0"),
+                    is_overallocated=is_over,
+                )
+            )
+
+        # Act
+        weekly_data = service._aggregate_to_weekly(daily_data)
+
+        # Assert
+        assert len(weekly_data) == 1
+        assert weekly_data[0].is_overallocated is True
+
+
+class TestStatisticsCalculation:
+    """Tests for statistics calculation."""
+
+    def test_calculate_statistics(self) -> None:
+        """Should calculate correct statistics."""
+        mock_session = MagicMock()
+        service = ResourceHistogramService(mock_session)
+
+        data_points = [
+            HistogramDataPoint(
+                date=date(2024, 1, 15),
+                available_hours=Decimal("8.0"),
+                assigned_hours=Decimal("4.0"),
+                utilization_percent=Decimal("50.0"),
+                is_overallocated=False,
+            ),
+            HistogramDataPoint(
+                date=date(2024, 1, 16),
+                available_hours=Decimal("8.0"),
+                assigned_hours=Decimal("8.0"),
+                utilization_percent=Decimal("100.0"),
+                is_overallocated=False,
+            ),
+            HistogramDataPoint(
+                date=date(2024, 1, 17),
+                available_hours=Decimal("8.0"),
+                assigned_hours=Decimal("10.0"),
+                utilization_percent=Decimal("125.0"),
+                is_overallocated=True,
+            ),
+        ]
+
+        # Act
+        stats = service._calculate_statistics(data_points)
+
+        # Assert
+        assert stats["peak_utilization"] == Decimal("125.0")
+        assert stats["peak_date"] == date(2024, 1, 17)
+        assert stats["average_utilization"] == Decimal("275.0") / 3
+        assert stats["overallocated_days"] == 1
+        assert stats["total_available_hours"] == Decimal("24.0")
+        assert stats["total_assigned_hours"] == Decimal("22.0")
+
+    def test_empty_data_points(self) -> None:
+        """Should handle empty data points."""
+        mock_session = MagicMock()
+        service = ResourceHistogramService(mock_session)
+
+        stats = service._calculate_statistics([])
+
+        assert stats["peak_utilization"] == Decimal("0")
+        assert stats["peak_date"] is None
+        assert stats["average_utilization"] == Decimal("0")
+        assert stats["overallocated_days"] == 0
+
+
+class TestGetProgramHistogram:
+    """Tests for get_program_histogram method."""
+
+    @pytest.mark.asyncio
+    async def test_program_histogram(self) -> None:
+        """Should generate histograms for all resources in program."""
+        mock_session = MagicMock()
+        service = ResourceHistogramService(mock_session)
+
+        program_id = uuid4()
+        resource1_id = uuid4()
+        resource2_id = uuid4()
+
+        # Mock program
+        mock_program = MagicMock()
+        mock_program.start_date = date(2024, 1, 1)
+        mock_program.end_date = date(2024, 12, 31)
+        service._program_repo = MagicMock()
+        service._program_repo.get_by_id = AsyncMock(return_value=mock_program)
+
+        # Mock resources
+        mock_resource1 = MagicMock()
+        mock_resource1.id = resource1_id
+        mock_resource1.code = "ENG-001"
+        mock_resource1.name = "Engineer 1"
+        mock_resource1.resource_type = ResourceType.LABOR
+        mock_resource1.capacity_per_day = Decimal("8.0")
+
+        mock_resource2 = MagicMock()
+        mock_resource2.id = resource2_id
+        mock_resource2.code = "ENG-002"
+        mock_resource2.name = "Engineer 2"
+        mock_resource2.resource_type = ResourceType.LABOR
+        mock_resource2.capacity_per_day = Decimal("8.0")
+
+        service._resource_repo = MagicMock()
+        service._resource_repo.get_by_program = AsyncMock(
+            return_value=([mock_resource1, mock_resource2], 2)
+        )
+        service._resource_repo.get_by_id = AsyncMock(
+            side_effect=lambda id: mock_resource1 if id == resource1_id else mock_resource2
+        )
+
+        # Mock loading service
+        service._loading_service = MagicMock()
+        service._loading_service.calculate_daily_loading = AsyncMock(return_value={})
+
+        # Act
+        summary, histograms = await service.get_program_histogram(
+            program_id, date(2024, 1, 1), date(2024, 1, 5)
+        )
+
+        # Assert
+        assert summary.program_id == program_id
+        assert summary.resource_count == 2
+        assert len(histograms) == 2
+
+    @pytest.mark.asyncio
+    async def test_program_not_found(self) -> None:
+        """Should return empty result if program not found."""
+        mock_session = MagicMock()
+        service = ResourceHistogramService(mock_session)
+
+        service._program_repo = MagicMock()
+        service._program_repo.get_by_id = AsyncMock(return_value=None)
+
+        summary, histograms = await service.get_program_histogram(
+            uuid4(), date(2024, 1, 1), date(2024, 1, 31)
+        )
+
+        assert summary.resource_count == 0
+        assert len(histograms) == 0
+
+    @pytest.mark.asyncio
+    async def test_filter_by_resource_ids(self) -> None:
+        """Should filter to specified resources."""
+        mock_session = MagicMock()
+        service = ResourceHistogramService(mock_session)
+
+        program_id = uuid4()
+        resource1_id = uuid4()
+        resource2_id = uuid4()
+
+        # Mock program
+        mock_program = MagicMock()
+        mock_program.start_date = date(2024, 1, 1)
+        mock_program.end_date = date(2024, 12, 31)
+        service._program_repo = MagicMock()
+        service._program_repo.get_by_id = AsyncMock(return_value=mock_program)
+
+        # Mock resources - return 2, but we'll filter to 1
+        mock_resource1 = MagicMock()
+        mock_resource1.id = resource1_id
+        mock_resource1.code = "ENG-001"
+        mock_resource1.name = "Engineer 1"
+        mock_resource1.resource_type = ResourceType.LABOR
+        mock_resource1.capacity_per_day = Decimal("8.0")
+
+        mock_resource2 = MagicMock()
+        mock_resource2.id = resource2_id
+        mock_resource2.code = "ENG-002"
+        mock_resource2.name = "Engineer 2"
+        mock_resource2.resource_type = ResourceType.LABOR
+        mock_resource2.capacity_per_day = Decimal("8.0")
+
+        service._resource_repo = MagicMock()
+        service._resource_repo.get_by_program = AsyncMock(
+            return_value=([mock_resource1, mock_resource2], 2)
+        )
+        service._resource_repo.get_by_id = AsyncMock(return_value=mock_resource1)
+
+        # Mock loading service
+        service._loading_service = MagicMock()
+        service._loading_service.calculate_daily_loading = AsyncMock(return_value={})
+
+        # Act - filter to only resource1
+        summary, histograms = await service.get_program_histogram(
+            program_id,
+            date(2024, 1, 1),
+            date(2024, 1, 5),
+            resource_ids=[resource1_id],
+        )
+
+        # Assert - should only have 1 histogram
+        assert summary.resource_count == 1
+        assert len(histograms) == 1
+        assert histograms[0].resource_id == resource1_id


### PR DESCRIPTION
## Summary
- Add `ResourceHistogramService` with histogram data generation for capacity planning
- Implement `get_resource_histogram` with daily/weekly granularity support
- Implement `get_program_histogram` for multi-resource program-wide view
- Add statistics calculation (peak utilization, average, overallocated days)
- Add API endpoints for single resource and program histograms

## Changes
- `api/src/services/resource_histogram.py` - Core service with dataclasses
- `api/src/schemas/histogram.py` - Pydantic response schemas
- `api/src/api/v1/endpoints/histogram.py` - API endpoints
- `api/src/api/v1/router.py` - Router registration
- `api/tests/unit/test_histogram.py` - 15 unit tests
- `api/tests/integration/test_histogram_api.py` - 8 integration tests

## API Endpoints
- `GET /api/v1/resources/{resource_id}/histogram` - Single resource histogram
- `GET /api/v1/programs/{program_id}/histogram` - Program-wide histogram

## Test plan
- [x] Unit tests pass (15 tests)
- [x] Integration tests pass (8 tests)
- [x] Ruff linting passes
- [x] Mypy type checking passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)