### PR TITLE
feat(frontend): ResourceList and ResourceForm components

### DIFF
--- a/web/src/components/Resources/ResourceForm.tsx
+++ b/web/src/components/Resources/ResourceForm.tsx
@@ -1,0 +1,233 @@
+/**
+ * ResourceForm modal component for creating and editing resources.
+ */
+
+import { useState, FormEvent } from "react";
+import type { Resource } from "@/types/resource";
+import { ResourceType } from "@/types/resource";
+import { useCreateResource, useUpdateResource } from "@/hooks/useResources";
+import { useToast } from "@/components/Toast";
+import { X } from "lucide-react";
+
+interface ResourceFormProps {
+  programId: string;
+  resource: Resource | null;
+  onClose: () => void;
+}
+
+export function ResourceForm({ programId, resource, onClose }: ResourceFormProps) {
+  const [formData, setFormData] = useState({
+    name: resource?.name || "",
+    code: resource?.code || "",
+    resource_type: resource?.resource_type || ResourceType.LABOR,
+    capacity_per_day: resource?.capacity_per_day || 8,
+    cost_rate: resource?.cost_rate?.toString() || "",
+    is_active: resource?.is_active ?? true,
+  });
+
+  const createResource = useCreateResource();
+  const updateResource = useUpdateResource();
+  const { success, error: showError } = useToast();
+  const isEditing = !!resource;
+
+  const handleSubmit = async (e: FormEvent) => {
+    e.preventDefault();
+
+    try {
+      if (isEditing) {
+        await updateResource.mutateAsync({
+          id: resource.id,
+          data: {
+            name: formData.name,
+            code: formData.code,
+            resource_type: formData.resource_type,
+            capacity_per_day: formData.capacity_per_day,
+            cost_rate: formData.cost_rate ? Number(formData.cost_rate) : undefined,
+            is_active: formData.is_active,
+          },
+        });
+        success("Resource updated successfully");
+      } else {
+        await createResource.mutateAsync({
+          program_id: programId,
+          name: formData.name,
+          code: formData.code,
+          resource_type: formData.resource_type,
+          capacity_per_day: formData.capacity_per_day,
+          cost_rate: formData.cost_rate ? Number(formData.cost_rate) : undefined,
+          is_active: formData.is_active,
+        });
+        success("Resource created successfully");
+      }
+      onClose();
+    } catch {
+      showError(`Failed to ${isEditing ? "update" : "create"} resource`);
+    }
+  };
+
+  const handleBackdropClick = (e: React.MouseEvent) => {
+    if (e.target === e.currentTarget) {
+      onClose();
+    }
+  };
+
+  const isPending = createResource.isPending || updateResource.isPending;
+
+  return (
+    <div
+      className="fixed inset-0 bg-black bg-opacity-50 flex items-center justify-center z-50"
+      onClick={handleBackdropClick}
+    >
+      <div className="bg-white rounded-lg p-6 w-full max-w-md shadow-xl">
+        <div className="flex justify-between items-center mb-4">
+          <h3 className="text-lg font-semibold">
+            {isEditing ? "Edit Resource" : "New Resource"}
+          </h3>
+          <button
+            onClick={onClose}
+            className="text-gray-500 hover:text-gray-700"
+            type="button"
+          >
+            <X size={20} />
+          </button>
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          <div className="space-y-4">
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Code <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={formData.code}
+                onChange={(e) =>
+                  setFormData({ ...formData, code: e.target.value.toUpperCase() })
+                }
+                className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+                pattern="[A-Z0-9\-_]+"
+                placeholder="e.g., ENG-001"
+                title="Code must contain only uppercase letters, numbers, hyphens, and underscores"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Name <span className="text-red-500">*</span>
+              </label>
+              <input
+                type="text"
+                value={formData.name}
+                onChange={(e) => setFormData({ ...formData, name: e.target.value })}
+                className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                required
+                placeholder="e.g., Senior Engineer"
+              />
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">Type</label>
+              <select
+                value={formData.resource_type}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    resource_type: e.target.value as ResourceType,
+                  })
+                }
+                className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+              >
+                <option value={ResourceType.LABOR}>Labor</option>
+                <option value={ResourceType.EQUIPMENT}>Equipment</option>
+                <option value={ResourceType.MATERIAL}>Material</option>
+              </select>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Capacity per Day (hours)
+              </label>
+              <input
+                type="number"
+                value={formData.capacity_per_day}
+                onChange={(e) =>
+                  setFormData({
+                    ...formData,
+                    capacity_per_day: Number(e.target.value),
+                  })
+                }
+                className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                min="0"
+                max="24"
+                step="0.5"
+              />
+              <p className="text-xs text-gray-500 mt-1">
+                Standard work day is 8 hours
+              </p>
+            </div>
+
+            <div>
+              <label className="block text-sm font-medium mb-1">
+                Cost Rate ($/hour)
+              </label>
+              <input
+                type="number"
+                value={formData.cost_rate}
+                onChange={(e) =>
+                  setFormData({ ...formData, cost_rate: e.target.value })
+                }
+                className="w-full border rounded px-3 py-2 focus:outline-none focus:ring-2 focus:ring-blue-500"
+                min="0"
+                step="0.01"
+                placeholder="Optional"
+              />
+            </div>
+
+            <div className="flex items-center">
+              <input
+                type="checkbox"
+                id="is_active"
+                checked={formData.is_active}
+                onChange={(e) =>
+                  setFormData({ ...formData, is_active: e.target.checked })
+                }
+                className="mr-2 h-4 w-4"
+              />
+              <label htmlFor="is_active" className="text-sm">
+                Active
+              </label>
+            </div>
+          </div>
+
+          <div className="flex justify-end gap-2 mt-6">
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-4 py-2 border rounded hover:bg-gray-50 transition-colors"
+              disabled={isPending}
+            >
+              Cancel
+            </button>
+            <button
+              type="submit"
+              className="px-4 py-2 bg-blue-500 text-white rounded hover:bg-blue-600 transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+              disabled={isPending}
+            >
+              {isPending ? (
+                <span className="flex items-center gap-2">
+                  <span className="animate-spin h-4 w-4 border-2 border-white border-t-transparent rounded-full" />
+                  {isEditing ? "Updating..." : "Creating..."}
+                </span>
+              ) : isEditing ? (
+                "Update"
+              ) : (
+                "Create"
+              )}
+            </button>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/Resources/ResourceList.tsx
+++ b/web/src/components/Resources/ResourceList.tsx
@@ -1,0 +1,186 @@
+/**
+ * ResourceList component for managing resources.
+ * Displays a table of resources with filtering, create, edit, and delete actions.
+ */
+
+import { useState } from "react";
+import { useResources, useDeleteResource } from "@/hooks/useResources";
+import { ResourceForm } from "./ResourceForm";
+import type { Resource } from "@/types/resource";
+import { ResourceType } from "@/types/resource";
+import { Plus, Edit2, Trash2, Users, Wrench, Package } from "lucide-react";
+import { useToast } from "@/components/Toast";
+
+interface ResourceListProps {
+  programId: string;
+}
+
+export function ResourceList({ programId }: ResourceListProps) {
+  const [showForm, setShowForm] = useState(false);
+  const [editingResource, setEditingResource] = useState<Resource | null>(null);
+  const [typeFilter, setTypeFilter] = useState<string>("");
+
+  const { data, isLoading, error } = useResources(programId, {
+    resource_type: typeFilter || undefined,
+  });
+  const deleteResource = useDeleteResource();
+  const { success, error: showError } = useToast();
+
+  const getTypeIcon = (type: ResourceType) => {
+    switch (type) {
+      case ResourceType.LABOR:
+        return <Users size={16} />;
+      case ResourceType.EQUIPMENT:
+        return <Wrench size={16} />;
+      case ResourceType.MATERIAL:
+        return <Package size={16} />;
+    }
+  };
+
+  const handleEdit = (resource: Resource) => {
+    setEditingResource(resource);
+    setShowForm(true);
+  };
+
+  const handleCreate = () => {
+    setEditingResource(null);
+    setShowForm(true);
+  };
+
+  const handleCloseForm = () => {
+    setShowForm(false);
+    setEditingResource(null);
+  };
+
+  const handleDelete = async (id: string) => {
+    if (confirm("Are you sure you want to delete this resource?")) {
+      try {
+        await deleteResource.mutateAsync(id);
+        success("Resource deleted successfully");
+      } catch {
+        showError("Failed to delete resource");
+      }
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="p-4 text-gray-500">Loading resources...</div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="p-4 text-red-500">
+        Error loading resources: {error instanceof Error ? error.message : "Unknown error"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="resource-list">
+      <div className="flex justify-between items-center mb-4">
+        <h2 className="text-xl font-semibold">Resources</h2>
+        <div className="flex gap-2">
+          <select
+            value={typeFilter}
+            onChange={(e) => setTypeFilter(e.target.value)}
+            className="border rounded px-2 py-1 text-sm"
+          >
+            <option value="">All Types</option>
+            <option value="LABOR">Labor</option>
+            <option value="EQUIPMENT">Equipment</option>
+            <option value="MATERIAL">Material</option>
+          </select>
+          <button
+            onClick={handleCreate}
+            className="bg-blue-500 text-white px-4 py-2 rounded flex items-center gap-2 hover:bg-blue-600 transition-colors"
+          >
+            <Plus size={16} /> Add Resource
+          </button>
+        </div>
+      </div>
+
+      {data?.items.length === 0 ? (
+        <div className="text-center py-8 text-gray-500">
+          <Package size={48} className="mx-auto mb-2 opacity-50" />
+          <p>No resources found.</p>
+          <button
+            onClick={handleCreate}
+            className="mt-2 text-blue-500 hover:underline"
+          >
+            Create your first resource
+          </button>
+        </div>
+      ) : (
+        <table className="w-full border-collapse">
+          <thead>
+            <tr className="bg-gray-100">
+              <th className="border p-2 text-left">Code</th>
+              <th className="border p-2 text-left">Name</th>
+              <th className="border p-2 text-left">Type</th>
+              <th className="border p-2 text-right">Capacity/Day</th>
+              <th className="border p-2 text-right">Cost Rate</th>
+              <th className="border p-2 text-center">Active</th>
+              <th className="border p-2 text-center">Actions</th>
+            </tr>
+          </thead>
+          <tbody>
+            {data?.items.map((resource) => (
+              <tr key={resource.id} className="hover:bg-gray-50">
+                <td className="border p-2 font-mono text-sm">{resource.code}</td>
+                <td className="border p-2">{resource.name}</td>
+                <td className="border p-2">
+                  <span className="flex items-center gap-1">
+                    {getTypeIcon(resource.resource_type)}
+                    <span className="text-sm">{resource.resource_type}</span>
+                  </span>
+                </td>
+                <td className="border p-2 text-right">{resource.capacity_per_day}h</td>
+                <td className="border p-2 text-right">
+                  {resource.cost_rate ? `$${resource.cost_rate}/h` : "-"}
+                </td>
+                <td className="border p-2 text-center">
+                  <span className={resource.is_active ? "text-green-600" : "text-gray-400"}>
+                    {resource.is_active ? "Active" : "Inactive"}
+                  </span>
+                </td>
+                <td className="border p-2 text-center">
+                  <button
+                    onClick={() => handleEdit(resource)}
+                    className="text-blue-500 hover:text-blue-700 mr-2"
+                    title="Edit resource"
+                  >
+                    <Edit2 size={16} />
+                  </button>
+                  <button
+                    onClick={() => handleDelete(resource.id)}
+                    className="text-red-500 hover:text-red-700"
+                    title="Delete resource"
+                    disabled={deleteResource.isPending}
+                  >
+                    <Trash2 size={16} />
+                  </button>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+
+      {data && data.total > data.items.length && (
+        <div className="mt-4 text-sm text-gray-500 text-center">
+          Showing {data.items.length} of {data.total} resources
+        </div>
+      )}
+
+      {showForm && (
+        <ResourceForm
+          programId={programId}
+          resource={editingResource}
+          onClose={handleCloseForm}
+        />
+      )}
+    </div>
+  );
+}

--- a/web/src/components/Resources/index.ts
+++ b/web/src/components/Resources/index.ts
@@ -1,0 +1,2 @@
+export { ResourceList } from "./ResourceList";
+export { ResourceForm } from "./ResourceForm";

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -14,3 +14,4 @@ export {
 export { WBSTree } from './WBSTree/WBSTree';
 export { EVMSDashboard } from './EVMSDashboard/EVMSDashboard';
 export { ImportModal } from './Import/ImportModal';
+export { ResourceList, ResourceForm } from './Resources';

--- a/web/src/hooks/useResources.ts
+++ b/web/src/hooks/useResources.ts
@@ -1,0 +1,87 @@
+/**
+ * React Query hooks for Resource management API.
+ */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import {
+  getResources,
+  getResource,
+  createResource,
+  updateResource,
+  deleteResource,
+} from "@/services/resourceApi";
+import type { ResourceCreate, ResourceUpdate } from "@/types/resource";
+
+const RESOURCES_KEY = "resources";
+
+/**
+ * Hook to fetch resources for a program.
+ */
+export function useResources(
+  programId: string,
+  filters?: { resource_type?: string; is_active?: boolean }
+) {
+  return useQuery({
+    queryKey: [RESOURCES_KEY, programId, filters],
+    queryFn: () => getResources(programId, filters),
+    enabled: !!programId,
+  });
+}
+
+/**
+ * Hook to fetch a single resource.
+ */
+export function useResource(id: string) {
+  return useQuery({
+    queryKey: [RESOURCES_KEY, id],
+    queryFn: () => getResource(id),
+    enabled: !!id,
+  });
+}
+
+/**
+ * Hook to create a new resource.
+ */
+export function useCreateResource() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (data: ResourceCreate) => createResource(data),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: [RESOURCES_KEY] });
+      queryClient.invalidateQueries({
+        queryKey: [RESOURCES_KEY, variables.program_id],
+      });
+    },
+  });
+}
+
+/**
+ * Hook to update a resource.
+ */
+export function useUpdateResource() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: ({ id, data }: { id: string; data: ResourceUpdate }) =>
+      updateResource(id, data),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: [RESOURCES_KEY] });
+      queryClient.invalidateQueries({ queryKey: [RESOURCES_KEY, variables.id] });
+    },
+  });
+}
+
+/**
+ * Hook to delete a resource.
+ */
+export function useDeleteResource() {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: (id: string) => deleteResource(id),
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: [RESOURCES_KEY] });
+    },
+  });
+}

--- a/web/src/services/resourceApi.ts
+++ b/web/src/services/resourceApi.ts
@@ -1,0 +1,92 @@
+/**
+ * API service for Resource management endpoints.
+ */
+
+import { apiClient } from "@/api/client";
+import type {
+  Resource,
+  ResourceCreate,
+  ResourceUpdate,
+  ResourceListResponse,
+} from "@/types/resource";
+
+/**
+ * Get all resources for a program.
+ */
+export async function getResources(
+  programId: string,
+  params?: { resource_type?: string; is_active?: boolean }
+): Promise<ResourceListResponse> {
+  const searchParams = new URLSearchParams({ program_id: programId });
+  if (params?.resource_type) {
+    searchParams.append("resource_type", params.resource_type);
+  }
+  if (params?.is_active !== undefined) {
+    searchParams.append("is_active", String(params.is_active));
+  }
+  const response = await apiClient.get<ResourceListResponse>(
+    `/resources?${searchParams.toString()}`
+  );
+  return response.data;
+}
+
+/**
+ * Get a single resource by ID.
+ */
+export async function getResource(id: string): Promise<Resource> {
+  const response = await apiClient.get<Resource>(`/resources/${id}`);
+  return response.data;
+}
+
+/**
+ * Create a new resource.
+ */
+export async function createResource(data: ResourceCreate): Promise<Resource> {
+  const payload = {
+    program_id: data.program_id,
+    name: data.name,
+    code: data.code,
+    resource_type: data.resource_type,
+    capacity_per_day: data.capacity_per_day,
+    cost_rate: data.cost_rate,
+    effective_date: data.effective_date,
+    is_active: data.is_active,
+  };
+  const response = await apiClient.post<Resource>("/resources", payload);
+  return response.data;
+}
+
+/**
+ * Update an existing resource.
+ */
+export async function updateResource(
+  id: string,
+  data: ResourceUpdate
+): Promise<Resource> {
+  const payload: Record<string, unknown> = {};
+  if (data.name !== undefined) payload.name = data.name;
+  if (data.code !== undefined) payload.code = data.code;
+  if (data.resource_type !== undefined) payload.resource_type = data.resource_type;
+  if (data.capacity_per_day !== undefined) payload.capacity_per_day = data.capacity_per_day;
+  if (data.cost_rate !== undefined) payload.cost_rate = data.cost_rate;
+  if (data.effective_date !== undefined) payload.effective_date = data.effective_date;
+  if (data.is_active !== undefined) payload.is_active = data.is_active;
+
+  const response = await apiClient.put<Resource>(`/resources/${id}`, payload);
+  return response.data;
+}
+
+/**
+ * Delete a resource.
+ */
+export async function deleteResource(id: string): Promise<void> {
+  await apiClient.delete(`/resources/${id}`);
+}
+
+export const resourceApi = {
+  list: getResources,
+  get: getResource,
+  create: createResource,
+  update: updateResource,
+  delete: deleteResource,
+};

--- a/web/src/types/resource.ts
+++ b/web/src/types/resource.ts
@@ -1,0 +1,48 @@
+export enum ResourceType {
+  LABOR = "LABOR",
+  EQUIPMENT = "EQUIPMENT",
+  MATERIAL = "MATERIAL",
+}
+
+export interface Resource {
+  id: string;
+  program_id: string;
+  name: string;
+  code: string;
+  resource_type: ResourceType;
+  capacity_per_day: number;
+  cost_rate: number | null;
+  effective_date: string | null;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string | null;
+}
+
+export interface ResourceCreate {
+  program_id: string;
+  name: string;
+  code: string;
+  resource_type: ResourceType;
+  capacity_per_day?: number;
+  cost_rate?: number;
+  effective_date?: string;
+  is_active?: boolean;
+}
+
+export interface ResourceUpdate {
+  name?: string;
+  code?: string;
+  resource_type?: ResourceType;
+  capacity_per_day?: number;
+  cost_rate?: number;
+  effective_date?: string;
+  is_active?: boolean;
+}
+
+export interface ResourceListResponse {
+  items: Resource[];
+  total: number;
+  page: number;
+  page_size: number;
+  pages: number;
+}


### PR DESCRIPTION
## Summary
- Add Resource TypeScript types (`web/src/types/resource.ts`)
- Add resourceApi service for CRUD operations (`web/src/services/resourceApi.ts`)
- Add useResources React Query hooks (`web/src/hooks/useResources.ts`)
- Add ResourceList component with filtering and CRUD actions
- Add ResourceForm modal for create/edit resources
- Export components from `web/src/components/index.ts`

## Components Added

### ResourceList
- Table display of resources with code, name, type, capacity, cost rate, status
- Type filter dropdown (Labor/Equipment/Material)
- Add, Edit, Delete actions
- Empty state handling
- Loading and error states

### ResourceForm
- Modal form for create/edit
- Field validation (code pattern, required fields)
- Resource type selection
- Capacity and cost rate inputs
- Active status toggle
- Loading state during submission

## Test plan
- [x] ESLint passes
- [x] TypeScript compiles (build succeeds)
- [x] Follows existing patterns from WBSTree/EVMSDashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)