### PR TITLE
feat(models): add resource cost and material quantity tracking

### DIFF
--- a/api/alembic/versions/010_resource_costs.py
+++ b/api/alembic/versions/010_resource_costs.py
@@ -1,0 +1,195 @@
+"""Add resource cost tracking fields.
+
+Revision ID: 010_resource_costs
+Revises: 009_api_keys
+Create Date: 2026-02-XX
+
+Adds:
+- Material quantity fields to resources
+- Cost tracking fields to resource_assignments
+- resource_cost_entries table for detailed tracking
+"""
+
+from alembic import op
+import sqlalchemy as sa
+from sqlalchemy.dialects.postgresql import UUID
+
+# revision identifiers, used by Alembic.
+revision = "010_resource_costs"
+down_revision = "009_api_keys"
+branch_labels = None
+depends_on = None
+
+
+def upgrade() -> None:
+    """Add resource cost and material quantity tracking."""
+    # Add material quantity fields to resources
+    op.add_column(
+        "resources",
+        sa.Column(
+            "quantity_unit",
+            sa.String(50),
+            nullable=True,
+            comment="Unit of measurement for materials (e.g., 'units', 'kg', 'meters')",
+        ),
+    )
+    op.add_column(
+        "resources",
+        sa.Column(
+            "unit_cost",
+            sa.Numeric(12, 2),
+            nullable=True,
+            comment="Cost per unit for MATERIAL type resources",
+        ),
+    )
+    op.add_column(
+        "resources",
+        sa.Column(
+            "quantity_available",
+            sa.Numeric(15, 2),
+            nullable=True,
+            comment="Total available quantity for MATERIAL type",
+        ),
+    )
+
+    # Add cost tracking fields to resource_assignments
+    op.add_column(
+        "resource_assignments",
+        sa.Column(
+            "planned_hours",
+            sa.Numeric(10, 2),
+            nullable=True,
+            comment="Planned hours for this assignment",
+        ),
+    )
+    op.add_column(
+        "resource_assignments",
+        sa.Column(
+            "actual_hours",
+            sa.Numeric(10, 2),
+            nullable=False,
+            server_default="0",
+            comment="Actual hours worked",
+        ),
+    )
+    op.add_column(
+        "resource_assignments",
+        sa.Column(
+            "planned_cost",
+            sa.Numeric(15, 2),
+            nullable=True,
+            comment="Planned cost (planned_hours * cost_rate)",
+        ),
+    )
+    op.add_column(
+        "resource_assignments",
+        sa.Column(
+            "actual_cost",
+            sa.Numeric(15, 2),
+            nullable=False,
+            server_default="0",
+            comment="Actual cost incurred",
+        ),
+    )
+
+    # Add material quantity fields to resource_assignments
+    op.add_column(
+        "resource_assignments",
+        sa.Column(
+            "quantity_assigned",
+            sa.Numeric(15, 2),
+            nullable=True,
+            comment="Quantity assigned for MATERIAL type",
+        ),
+    )
+    op.add_column(
+        "resource_assignments",
+        sa.Column(
+            "quantity_consumed",
+            sa.Numeric(15, 2),
+            nullable=False,
+            server_default="0",
+            comment="Quantity consumed for MATERIAL type",
+        ),
+    )
+
+    # Create resource_cost_entries table for detailed cost tracking
+    op.create_table(
+        "resource_cost_entries",
+        sa.Column("id", UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "assignment_id",
+            UUID(as_uuid=True),
+            sa.ForeignKey("resource_assignments.id", ondelete="CASCADE"),
+            nullable=False,
+        ),
+        sa.Column("entry_date", sa.Date, nullable=False),
+        sa.Column(
+            "hours_worked",
+            sa.Numeric(6, 2),
+            nullable=False,
+            server_default="0",
+            comment="Hours worked on this date",
+        ),
+        sa.Column(
+            "cost_incurred",
+            sa.Numeric(12, 2),
+            nullable=False,
+            server_default="0",
+            comment="Cost incurred on this date",
+        ),
+        sa.Column(
+            "quantity_used",
+            sa.Numeric(15, 2),
+            nullable=True,
+            comment="Quantity used for MATERIAL type resources",
+        ),
+        sa.Column("notes", sa.Text, nullable=True),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("updated_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column("deleted_at", sa.DateTime(timezone=True), nullable=True),
+    )
+
+    # Indexes for resource_cost_entries
+    op.create_index(
+        "ix_resource_cost_entries_assignment_id",
+        "resource_cost_entries",
+        ["assignment_id"],
+    )
+    op.create_index(
+        "ix_resource_cost_entries_entry_date",
+        "resource_cost_entries",
+        ["entry_date"],
+    )
+    op.create_index(
+        "ix_resource_cost_entries_assignment_date",
+        "resource_cost_entries",
+        ["assignment_id", "entry_date"],
+    )
+
+
+def downgrade() -> None:
+    """Remove resource cost tracking."""
+    # Drop resource_cost_entries table
+    op.drop_index("ix_resource_cost_entries_assignment_date")
+    op.drop_index("ix_resource_cost_entries_entry_date")
+    op.drop_index("ix_resource_cost_entries_assignment_id")
+    op.drop_table("resource_cost_entries")
+
+    # Remove columns from resource_assignments
+    op.drop_column("resource_assignments", "quantity_consumed")
+    op.drop_column("resource_assignments", "quantity_assigned")
+    op.drop_column("resource_assignments", "actual_cost")
+    op.drop_column("resource_assignments", "planned_cost")
+    op.drop_column("resource_assignments", "actual_hours")
+    op.drop_column("resource_assignments", "planned_hours")
+
+    # Remove columns from resources
+    op.drop_column("resources", "quantity_available")
+    op.drop_column("resources", "unit_cost")
+    op.drop_column("resources", "quantity_unit")

--- a/api/src/models/__init__.py
+++ b/api/src/models/__init__.py
@@ -45,6 +45,9 @@ from src.models.report_audit import ReportAudit
 # Week 14: Resource models
 from src.models.resource import Resource, ResourceAssignment, ResourceCalendar
 
+# Week 17: Resource cost tracking
+from src.models.resource_cost import ResourceCostEntry
+
 # Import models
 from src.models.user import User
 from src.models.variance_explanation import VarianceExplanation
@@ -77,6 +80,8 @@ __all__ = [
     "Resource",
     "ResourceAssignment",
     "ResourceCalendar",
+    # Week 17: Resource cost tracking
+    "ResourceCostEntry",
     "SoftDeleteMixin",
     "SyncDirection",
     "SyncStatus",

--- a/api/src/models/resource_cost.py
+++ b/api/src/models/resource_cost.py
@@ -1,0 +1,98 @@
+"""Resource cost entry model for detailed cost tracking."""
+
+from datetime import date
+from decimal import Decimal
+from typing import TYPE_CHECKING
+from uuid import UUID
+
+from sqlalchemy import Date, ForeignKey, Index, Numeric, Text
+from sqlalchemy.dialects.postgresql import UUID as PGUUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from src.models.base import Base
+
+if TYPE_CHECKING:
+    from src.models.resource import ResourceAssignment
+
+
+class ResourceCostEntry(Base):
+    """
+    Detailed cost tracking entry for resource assignments.
+
+    Records actual hours worked and costs incurred on specific dates.
+    Used for accurate ACWP calculation in EVMS.
+
+    Attributes:
+        assignment_id: FK to parent resource assignment
+        entry_date: Date of the cost entry
+        hours_worked: Hours worked on this date
+        cost_incurred: Cost incurred on this date
+        quantity_used: Quantity used for MATERIAL type resources
+        notes: Optional notes for this entry
+    """
+
+    __tablename__ = "resource_cost_entries"
+
+    assignment_id: Mapped[UUID] = mapped_column(
+        PGUUID(as_uuid=True),
+        ForeignKey("resource_assignments.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+        comment="FK to parent resource assignment",
+    )
+
+    entry_date: Mapped[date] = mapped_column(
+        Date,
+        nullable=False,
+        index=True,
+        comment="Date of the cost entry",
+    )
+
+    hours_worked: Mapped[Decimal] = mapped_column(
+        Numeric(precision=6, scale=2),
+        nullable=False,
+        default=Decimal("0"),
+        comment="Hours worked on this date",
+    )
+
+    cost_incurred: Mapped[Decimal] = mapped_column(
+        Numeric(precision=12, scale=2),
+        nullable=False,
+        default=Decimal("0"),
+        comment="Cost incurred on this date",
+    )
+
+    quantity_used: Mapped[Decimal | None] = mapped_column(
+        Numeric(precision=15, scale=2),
+        nullable=True,
+        comment="Quantity used for MATERIAL type resources",
+    )
+
+    notes: Mapped[str | None] = mapped_column(
+        Text,
+        nullable=True,
+        comment="Optional notes for this entry",
+    )
+
+    # Relationships
+    assignment: Mapped["ResourceAssignment"] = relationship(
+        "ResourceAssignment",
+        back_populates="cost_entries",
+    )
+
+    # Table-level configuration
+    __table_args__ = (
+        Index(
+            "ix_resource_cost_entries_assignment_date",
+            "assignment_id",
+            "entry_date",
+        ),
+        {"comment": "Detailed cost tracking entries for resource assignments"},
+    )
+
+    def __repr__(self) -> str:
+        """Return string representation for debugging."""
+        return (
+            f"<ResourceCostEntry(id={self.id}, assignment_id={self.assignment_id}, "
+            f"date={self.entry_date}, hours={self.hours_worked}, cost={self.cost_incurred})>"
+        )


### PR DESCRIPTION
## Summary

Add cost tracking fields to resource models for EVMS ACWP integration and material management.

## Changes

### Migration 010_resource_costs
- Add material quantity fields to `resources` table
- Add cost tracking fields to `resource_assignments` table
- Create `resource_cost_entries` table for detailed tracking

### Resource Model Updates
| Field | Type | Description |
|-------|------|-------------|
| `quantity_unit` | String(50) | Unit of measurement for MATERIAL type |
| `unit_cost` | Decimal(12,2) | Cost per unit for MATERIAL type |
| `quantity_available` | Decimal(15,2) | Total available quantity |

### ResourceAssignment Model Updates
| Field | Type | Description |
|-------|------|-------------|
| `planned_hours` | Decimal(10,2) | Planned hours for assignment |
| `actual_hours` | Decimal(10,2) | Actual hours worked |
| `planned_cost` | Decimal(15,2) | Planned cost |
| `actual_cost` | Decimal(15,2) | Actual cost incurred |
| `quantity_assigned` | Decimal(15,2) | Quantity for MATERIAL type |
| `quantity_consumed` | Decimal(15,2) | Consumed quantity |

### New ResourceCostEntry Model
Detailed cost tracking entries for resource assignments with:
- `entry_date`: Date of the cost entry
- `hours_worked`: Hours worked on this date
- `cost_incurred`: Cost incurred on this date
- `quantity_used`: Quantity used for MATERIAL type
- `notes`: Optional notes

### Schema Updates
- Updated `ResourceCreate`, `ResourceUpdate`, `ResourceResponse`
- Updated `ResourceAssignmentCreate`, `ResourceAssignmentUpdate`, `ResourceAssignmentResponse`
- Added `CostEntryCreate`, `CostEntryUpdate`, `CostEntryResponse`, `CostEntryListResponse`

## Test plan

- [x] Ruff linting passed
- [x] Mypy type checking passed (140 files)
- [x] Resource unit tests passed (104 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)