### PR TITLE
feat(frontend): add GanttResourceView component

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -3,7 +3,7 @@
 > **Project**: Defense PM Tool with EVMS/CPM capabilities
 > **Repository**: https://github.com/jason-marshall/defense-pm-tool
 > **Developer**: Single developer, 3-month timeline
-> **Current Phase**: Week 20 Complete - v1.2.0 Resource Pools
+> **Current Phase**: Week 21 In Progress - Gantt Resource View
 
 ---
 
@@ -811,10 +811,17 @@ Defense PM Tool v1.1.0 Resource Management Release:
 **PARALLEL NOTE**: This branch runs alongside Weeks 17, 18, 19.
 Do not merge until all parallel branches complete.
 
+### 🔶 In Progress (Week 21: Gantt Resource View)
+**Branch: feature/week21-gantt-resource**
+- [ ] GanttChart React component with D3.js
+- [ ] Resource lane visualization
+- [ ] Activity bar rendering with dependencies
+- [ ] Resource assignment overlay
+- [ ] Interactive zoom and scroll
+- [ ] Week 21 E2E tests
+
 ### ⏳ Upcoming (v1.2.0)
-- [ ] MS Project resource calendar import (Week 18)
-- [ ] Parallel resource leveling algorithm (Week 19)
-- [ ] Gantt chart with resource view (Week 21-22)
+- [ ] Gantt interactions and editing (Week 22)
 
 ## v1.0.0 RELEASE COMPLETE
 
@@ -1056,7 +1063,7 @@ See `api/docs/PERFORMANCE.md` for detailed analysis and optimization recommendat
 ---
 
 *Last Updated: February 2026*
-*v1.1.0 RELEASED - February 2026*
-*Week 20 COMPLETE: v1.2.0 Resource Pools*
+*v1.2.0 RELEASED - February 2026*
+*Week 21 IN PROGRESS: Gantt Resource View*
 *2775+ tests, 81%+ coverage, 77+ API endpoints*
-*Week 20: Cross-Program Resource Pools COMPLETE*
+*Week 21: Gantt Chart with Resource View*

--- a/web/package-lock.json
+++ b/web/package-lock.json
@@ -21,6 +21,8 @@
       "devDependencies": {
         "@eslint/js": "^9.39.2",
         "@tailwindcss/postcss": "^4.1.18",
+        "@testing-library/jest-dom": "^6.9.1",
+        "@testing-library/react": "^16.3.2",
         "@types/react": "^18.2.0",
         "@types/react-dom": "^18.2.0",
         "@typescript-eslint/eslint-plugin": "^8.53.1",
@@ -31,6 +33,7 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.5",
         "globals": "^17.1.0",
+        "jsdom": "^27.4.0",
         "postcss": "^8.4.32",
         "tailwindcss": "^4.1.18",
         "typescript": "^5.3.0",
@@ -38,6 +41,20 @@
         "vite": "^7.3.1",
         "vitest": "^4.0.17"
       }
+    },
+    "node_modules/@acemir/cssom": {
+      "version": "0.9.31",
+      "resolved": "https://registry.npmjs.org/@acemir/cssom/-/cssom-0.9.31.tgz",
+      "integrity": "sha512-ZnR3GSaH+/vJ0YlHau21FjfLYjMpYVIzTD8M8vIEQvIGxeOXyXdzCI140rrCY862p/C/BbzWsjc1dgnM9mkoTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.4.4",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.4.4.tgz",
+      "integrity": "sha512-Elp+iwUx5rN5+Y8xLt5/GRoG20WGoDCQ/1Fb+1LiGtvwbDavuSk0jhD/eZdckHAuzcDzccnkv+rEjyWfRx18gg==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -51,6 +68,61 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-4.1.1.tgz",
+      "integrity": "sha512-B0Hv6G3gWGMn0xKJ0txEi/jM5iFpT3MfDxmhZFb4W047GvytCf1DHQ1D69W3zHI4yWe2aTZAA0JnbMZ7Xc8DuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.4",
+        "@csstools/css-color-parser": "^3.1.0",
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector": {
+      "version": "6.7.6",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/dom-selector/-/dom-selector-6.7.6.tgz",
+      "integrity": "sha512-hBaJER6A9MpdG3WgdlOolHmbOYvSk46y7IQN/1+iqiCuUu6iWdQrs9DGKF8ocqsEqWujWf/V7b7vaDgiUmIvUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/nwsapi": "^2.3.9",
+        "bidi-js": "^1.0.3",
+        "css-tree": "^3.1.0",
+        "is-potential-custom-element-name": "^1.0.1",
+        "lru-cache": "^11.2.4"
+      }
+    },
+    "node_modules/@asamuzakjp/dom-selector/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
+    "node_modules/@asamuzakjp/nwsapi": {
+      "version": "2.3.9",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/nwsapi/-/nwsapi-2.3.9.tgz",
+      "integrity": "sha512-n8GuYSrI9bF7FFZ/SjhwevlHc8xaVlb/7HmHelnc/PZXBD2ZR49NnN9sMMuDdEGPeeRQ5d0hqlSlEpgCX3Wl0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.27.1",
@@ -306,6 +378,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.28.6",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.28.6.tgz",
+      "integrity": "sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.27.2",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.27.2.tgz",
@@ -359,6 +441,138 @@
       "resolved": "https://registry.npmjs.org/@bcoe/v8-coverage/-/v8-coverage-1.0.2.tgz",
       "integrity": "sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==",
       "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-syntax-patches-for-csstree": {
+      "version": "1.0.26",
+      "resolved": "https://registry.npmjs.org/@csstools/css-syntax-patches-for-csstree/-/css-syntax-patches-for-csstree-1.0.26.tgz",
+      "integrity": "sha512-6boXK0KkzT5u5xOgF6TKB+CLq9SOpEGmkZw0g5n9/7yg85wab3UzSxB8TxhLJ31L4SGJ6BCFRw/iftTha1CJXA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0"
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
       "license": "MIT",
       "engines": {
         "node": ">=18"
@@ -996,6 +1210,24 @@
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
+      }
+    },
+    "node_modules/@exodus/bytes": {
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@exodus/bytes/-/bytes-1.10.0.tgz",
+      "integrity": "sha512-tf8YdcbirXdPnJ+Nd4UN1EXnz+IP2DI45YVEr3vvzcVTOyrApkmIB4zvOQVd3XPr7RXnfBtAx+PXImXOIU0Ajg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "@noble/hashes": "^1.8.0 || ^2.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@noble/hashes": {
+          "optional": true
+        }
       }
     },
     "node_modules/@humanfs/core": {
@@ -1862,6 +2094,102 @@
         "react": "^18 || ^19"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "peer": true,
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -2465,6 +2793,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2480,6 +2818,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2504,6 +2853,16 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.2",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.2.tgz",
+      "integrity": "sha512-COROpnaoap1E2F000S62r6A60uHZnmlvomhfyT2DlTcrY1OrBKn2UhH7qn5wTC9zMvD0AY7csdPSNwKP+7WiQw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">= 0.4"
+      }
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -2566,6 +2925,16 @@
       "license": "Apache-2.0",
       "bin": {
         "baseline-browser-mapping": "dist/cli.js"
+      }
+    },
+    "node_modules/bidi-js": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/bidi-js/-/bidi-js-1.0.3.tgz",
+      "integrity": "sha512-RKshQI1R3YQ+n9YJz2QQ147P66ELpa1FQEg20Dk8oW9t2KgLbpDLLp9aGZ7y8WHSshDknG0bknqGw5/tyCs5tw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "require-from-string": "^2.0.2"
       }
     },
     "node_modules/brace-expansion": {
@@ -2766,6 +3135,53 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css-tree": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-3.1.0.tgz",
+      "integrity": "sha512-0eW44TGN5SQXU1mWSkKwFstI/22X2bG1nYzZTYMAWjylYURhse752YgbE4Cx46AC+bAvI+/dYTPRk1LqSUnu6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mdn-data": "2.12.2",
+        "source-map-js": "^1.0.1"
+      },
+      "engines": {
+        "node": "^10 || ^12.20.0 || ^14.13.0 || >=15.0.0"
+      }
+    },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "5.3.7",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-5.3.7.tgz",
+      "integrity": "sha512-7D2EPVltRrsTkhpQmksIu+LxeWAIEk6wRDMJ1qljlv+CKHJM+cJLlfhWIzNA44eAsHXSNe3+vO6DW1yCYx8SuQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^4.1.1",
+        "@csstools/css-syntax-patches-for-csstree": "^1.0.21",
+        "css-tree": "^3.1.0",
+        "lru-cache": "^11.2.4"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/cssstyle/node_modules/lru-cache": {
+      "version": "11.2.5",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.2.5.tgz",
+      "integrity": "sha512-vFrFJkWtJvJnD5hg+hJvVE8Lh/TcMzKnTgCWmtBipwI5yLX/iX+5UB2tfuyODF5E7k9xEzMdYgGqaSb1c0c5Yw==",
+      "dev": true,
+      "license": "BlueOak-1.0.0",
+      "engines": {
+        "node": "20 || >=22"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
@@ -2894,6 +3310,30 @@
         "node": ">=12"
       }
     },
+    "node_modules/data-urls": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-6.0.1.tgz",
+      "integrity": "sha512-euIQENZg6x8mj3fO6o9+fOW8MimUI4PpD/fZBhJfeioZVy9TUpM4UY7KjQNVZFlqwJ0UdzRDzkycB997HEq1BQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^5.0.0",
+        "whatwg-url": "^15.1.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/data-urls/node_modules/whatwg-mimetype": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-5.0.0.tgz",
+      "integrity": "sha512-sXcNcHOC51uPGF0P/D4NVtrkjSU2fNsm9iog4ZvZJsL3rjoDAzXZhkm2MWt1y+PUdggKAYVoMAIYcs78wJ51Cw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
@@ -2922,6 +3362,13 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/decimal.js-light": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/decimal.js-light/-/decimal.js-light-2.5.1.tgz",
@@ -2944,6 +3391,17 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2953,6 +3411,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2987,6 +3452,19 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/es-define-property": {
@@ -3666,12 +4144,53 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-6.0.0.tgz",
+      "integrity": "sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@exodus/bytes": "^1.6.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      }
+    },
     "node_modules/html-escaper": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/html-escaper/-/html-escaper-2.0.2.tgz",
       "integrity": "sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
     },
     "node_modules/ignore": {
       "version": "5.3.2",
@@ -3720,6 +4239,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/internmap": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/internmap/-/internmap-2.0.3.tgz",
@@ -3751,6 +4280,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3825,6 +4361,46 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "27.4.0",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-27.4.0.tgz",
+      "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@acemir/cssom": "^0.9.28",
+        "@asamuzakjp/dom-selector": "^6.7.6",
+        "@exodus/bytes": "^1.6.0",
+        "cssstyle": "^5.3.4",
+        "data-urls": "^6.0.0",
+        "decimal.js": "^10.6.0",
+        "html-encoding-sniffer": "^6.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.6",
+        "is-potential-custom-element-name": "^1.0.1",
+        "parse5": "^8.0.0",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^6.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^8.0.0",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^15.1.0",
+        "ws": "^8.18.3",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=24.0.0"
+      },
+      "peerDependencies": {
+        "canvas": "^3.0.0"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -4213,6 +4789,17 @@
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
+      }
+    },
     "node_modules/magic-string": {
       "version": "0.30.21",
       "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
@@ -4260,6 +4847,13 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/mdn-data": {
+      "version": "2.12.2",
+      "resolved": "https://registry.npmjs.org/mdn-data/-/mdn-data-2.12.2.tgz",
+      "integrity": "sha512-IEn+pegP1aManZuckezWCO+XZQDplx1366JoVhTpMpBB1sPey/SbveZQUosKiKiGYjg1wH4pMlNgXbCiYgihQA==",
+      "dev": true,
+      "license": "CC0-1.0"
+    },
     "node_modules/mime-db": {
       "version": "1.52.0",
       "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
@@ -4279,6 +4873,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -4411,6 +5015,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-8.0.0.tgz",
+      "integrity": "sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -4483,6 +5100,44 @@
       "engines": {
         "node": ">= 0.8.0"
       }
+    },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/pretty-format/node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -4633,6 +5288,20 @@
         "react-is": "^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
       }
     },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/redux": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/redux/-/redux-5.0.1.tgz",
@@ -4646,6 +5315,16 @@
       "license": "MIT",
       "peerDependencies": {
         "redux": "^5.0.0"
+      }
+    },
+    "node_modules/require-from-string": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/require-from-string/-/require-from-string-2.0.2.tgz",
+      "integrity": "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/reselect": {
@@ -4707,6 +5386,19 @@
         "@rollup/rollup-win32-x64-gnu": "4.55.1",
         "@rollup/rollup-win32-x64-msvc": "4.55.1",
         "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
       }
     },
     "node_modules/scheduler": {
@@ -4791,6 +5483,19 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/strip-json-comments": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
@@ -4816,6 +5521,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
@@ -4917,6 +5629,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-7.0.19.tgz",
+      "integrity": "sha512-8PWx8tvC4jDB39BQw1m4x8y5MH1BcQ5xHeL2n7UVFulMPH/3Q0uiamahFJ3lXA0zO2SUyRXuVVbWSDmstlt9YA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^7.0.19"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "7.0.19",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-7.0.19.tgz",
+      "integrity": "sha512-lJX2dEWx0SGH4O6p+7FPwYmJ/bu1JbcGJ8RLaG9b7liIgZ85itUVEPbMtWRVrde/0fnDPEPHW10ZsKW3kVsE9A==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-6.0.0.tgz",
+      "integrity": "sha512-kXuRi1mtaKMrsLUxz3sQYvVl37B0Ns6MzfrtV5DvJceE9bPyspOqk9xxv7XbZWcfLWbFmm997vl83qUWVJA64w==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^7.0.5"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-6.0.0.tgz",
+      "integrity": "sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/ts-api-utils": {
@@ -5252,6 +6010,53 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-8.0.1.tgz",
+      "integrity": "sha512-BMhLD/Sw+GbJC21C/UgyaZX41nPt8bUTg+jWyDeg7e7YN4xOM05YPSIXceACnXVtqyEw/LMClUQMtMZ+PGGpqQ==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "15.1.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-15.1.0.tgz",
+      "integrity": "sha512-2ytDk0kiEj/yu90JOAp44PVPUkO9+jVhyf+SybKlRHSDlvOOZhdPIrr7xTH64l4WixO2cP+wQIcgujkGBPPz6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^6.0.0",
+        "webidl-conversions": "^8.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -5294,6 +6099,45 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.19.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
+      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/web/package.json
+++ b/web/package.json
@@ -25,6 +25,8 @@
   "devDependencies": {
     "@eslint/js": "^9.39.2",
     "@tailwindcss/postcss": "^4.1.18",
+    "@testing-library/jest-dom": "^6.9.1",
+    "@testing-library/react": "^16.3.2",
     "@types/react": "^18.2.0",
     "@types/react-dom": "^18.2.0",
     "@typescript-eslint/eslint-plugin": "^8.53.1",
@@ -35,6 +37,7 @@
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.5",
     "globals": "^17.1.0",
+    "jsdom": "^27.4.0",
     "postcss": "^8.4.32",
     "tailwindcss": "^4.1.18",
     "typescript": "^5.3.0",

--- a/web/src/components/GanttResource/AssignmentBars.tsx
+++ b/web/src/components/GanttResource/AssignmentBars.tsx
@@ -1,0 +1,109 @@
+/**
+ * AssignmentBars - Renders assignment bars for a resource lane.
+ */
+
+import { useCallback, type KeyboardEvent } from "react";
+import { differenceInDays } from "date-fns";
+import type {
+  AssignmentBar,
+  AssignmentChange,
+  GanttResourceViewConfig,
+} from "@/types/ganttResource";
+
+interface AssignmentBarsProps {
+  assignments: AssignmentBar[];
+  config: GanttResourceViewConfig;
+  dayWidth: number;
+  highlightOverallocations: boolean;
+  onAssignmentClick?: (assignmentId: string) => void;
+  onAssignmentChange?: (change: AssignmentChange) => void;
+}
+
+export function AssignmentBars({
+  assignments,
+  config,
+  dayWidth,
+  highlightOverallocations,
+  onAssignmentClick,
+  onAssignmentChange,
+}: AssignmentBarsProps) {
+  const handleClick = useCallback(
+    (assignmentId: string) => {
+      onAssignmentClick?.(assignmentId);
+    },
+    [onAssignmentClick]
+  );
+
+  const handleKeyDown = useCallback(
+    (e: KeyboardEvent, assignmentId: string) => {
+      if (e.key === "Delete" || e.key === "Backspace") {
+        onAssignmentChange?.({
+          assignmentId,
+          type: "delete",
+        });
+      }
+    },
+    [onAssignmentChange]
+  );
+
+  return (
+    <div className="assignment-bars" data-testid="assignment-bars">
+      {assignments.map((assignment) => {
+        const startOffset = differenceInDays(
+          assignment.startDate,
+          config.startDate
+        );
+        const duration =
+          differenceInDays(assignment.endDate, assignment.startDate) + 1;
+        const left = startOffset * dayWidth;
+        const width = duration * dayWidth;
+
+        // Skip bars that are outside the visible range
+        if (left + width < 0 || left > config.endDate.getTime()) {
+          return null;
+        }
+
+        // Determine bar color
+        let barColor = assignment.color || "#60a5fa"; // Default blue
+        if (assignment.isCritical) {
+          barColor = "#ef4444"; // Red for critical
+        }
+        if (highlightOverallocations && assignment.isOverallocated) {
+          barColor = "#f97316"; // Orange for overallocated
+        }
+
+        return (
+          <div
+            key={assignment.assignmentId}
+            className={`assignment-bar ${assignment.isCritical ? "critical" : ""} ${
+              highlightOverallocations && assignment.isOverallocated
+                ? "overallocated"
+                : ""
+            }`}
+            style={{
+              left: Math.max(0, left),
+              width: Math.max(dayWidth, width),
+              backgroundColor: barColor,
+            }}
+            onClick={() => handleClick(assignment.assignmentId)}
+            onKeyDown={(e) => handleKeyDown(e, assignment.assignmentId)}
+            tabIndex={0}
+            role="button"
+            aria-label={`${assignment.activityName} - ${assignment.units * 100}%`}
+            title={`${assignment.activityCode}: ${assignment.activityName}\nUnits: ${(assignment.units * 100).toFixed(0)}%${
+              assignment.isCritical ? "\n(Critical Path)" : ""
+            }${assignment.isOverallocated ? "\n(Overallocated)" : ""}`}
+            data-testid={`assignment-bar-${assignment.assignmentId}`}
+          >
+            <span className="assignment-bar-label">
+              {assignment.activityCode}
+            </span>
+            <span className="assignment-bar-units">
+              {(assignment.units * 100).toFixed(0)}%
+            </span>
+          </div>
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/GanttResource/GanttResourceView.css
+++ b/web/src/components/GanttResource/GanttResourceView.css
@@ -1,0 +1,359 @@
+/**
+ * GanttResourceView styles
+ */
+
+.gantt-resource-container {
+  display: flex;
+  flex-direction: column;
+  height: 100%;
+  min-height: 400px;
+  border: 1px solid #e5e7eb;
+  border-radius: 8px;
+  background: #fff;
+  overflow: hidden;
+}
+
+/* Loading and error states */
+.gantt-resource-loading,
+.gantt-resource-error {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 200px;
+  color: #6b7280;
+  font-size: 14px;
+}
+
+.gantt-resource-loading {
+  flex-direction: column;
+  gap: 12px;
+}
+
+.gantt-resource-spinner {
+  width: 24px;
+  height: 24px;
+  border: 3px solid #e5e7eb;
+  border-top-color: #3b82f6;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+.gantt-resource-error {
+  color: #ef4444;
+}
+
+/* Toolbar */
+.gantt-resource-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 16px;
+  padding: 12px 16px;
+  border-bottom: 1px solid #e5e7eb;
+  background: #f9fafb;
+}
+
+.scale-selector {
+  display: flex;
+  border: 1px solid #d1d5db;
+  border-radius: 6px;
+  overflow: hidden;
+}
+
+.scale-selector button {
+  padding: 6px 12px;
+  border: none;
+  background: #fff;
+  color: #374151;
+  font-size: 13px;
+  cursor: pointer;
+  transition: background-color 0.15s;
+}
+
+.scale-selector button:not(:last-child) {
+  border-right: 1px solid #d1d5db;
+}
+
+.scale-selector button:hover {
+  background: #f3f4f6;
+}
+
+.scale-selector button.active {
+  background: #3b82f6;
+  color: #fff;
+}
+
+.utilization-toggle,
+.overallocation-toggle {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 13px;
+  color: #374151;
+  cursor: pointer;
+}
+
+.utilization-toggle input,
+.overallocation-toggle input {
+  cursor: pointer;
+}
+
+/* Main content */
+.gantt-resource-content {
+  display: flex;
+  flex: 1;
+  overflow: hidden;
+}
+
+/* Sidebar */
+.gantt-resource-sidebar {
+  flex-shrink: 0;
+  border-right: 1px solid #e5e7eb;
+  background: #f9fafb;
+  overflow-y: auto;
+}
+
+.resource-sidebar-header {
+  display: flex;
+  align-items: center;
+  padding: 0 12px;
+  border-bottom: 1px solid #e5e7eb;
+  background: #f3f4f6;
+  font-weight: 600;
+  font-size: 13px;
+  color: #374151;
+}
+
+.resource-sidebar-rows {
+  display: flex;
+  flex-direction: column;
+}
+
+.resource-sidebar-row {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 0 12px;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.resource-sidebar-row:hover {
+  background: #f3f4f6;
+}
+
+.resource-type-badge {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  width: 20px;
+  height: 20px;
+  border-radius: 4px;
+  color: #fff;
+  font-size: 11px;
+  font-weight: 600;
+}
+
+.resource-info {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  min-width: 0;
+}
+
+.resource-code {
+  font-size: 12px;
+  font-weight: 600;
+  color: #374151;
+}
+
+.resource-name {
+  font-size: 11px;
+  color: #6b7280;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.resource-capacity {
+  font-size: 11px;
+  color: #9ca3af;
+  white-space: nowrap;
+}
+
+/* Chart area */
+.gantt-resource-chart {
+  flex: 1;
+  overflow: auto;
+  position: relative;
+}
+
+/* Timeline */
+.resource-timeline {
+  position: sticky;
+  top: 0;
+  z-index: 10;
+  background: #f9fafb;
+  border-bottom: 1px solid #e5e7eb;
+}
+
+.timeline-months {
+  display: flex;
+  height: 30px;
+  border-bottom: 1px solid #e5e7eb;
+  position: relative;
+}
+
+.timeline-month {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 12px;
+  font-weight: 600;
+  color: #374151;
+  border-right: 1px solid #e5e7eb;
+  background: #f3f4f6;
+}
+
+.timeline-days {
+  display: flex;
+  height: 30px;
+  position: relative;
+}
+
+.timeline-day {
+  position: absolute;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  height: 100%;
+  font-size: 11px;
+  color: #6b7280;
+  border-right: 1px solid #f3f4f6;
+}
+
+.timeline-day.weekend {
+  background: #fef3c7;
+}
+
+.timeline-day-label {
+  font-size: 10px;
+}
+
+/* Resource lanes */
+.gantt-resource-lanes {
+  position: relative;
+}
+
+.gantt-resource-lane {
+  position: absolute;
+  left: 0;
+  right: 0;
+  border-bottom: 1px solid #f3f4f6;
+}
+
+.gantt-resource-lane:nth-child(even) {
+  background: #fafafa;
+}
+
+/* Utilization overlay */
+.utilization-overlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  pointer-events: none;
+}
+
+.utilization-cell {
+  position: absolute;
+  top: 0;
+  height: 100%;
+}
+
+/* Assignment bars */
+.assignment-bars {
+  position: absolute;
+  top: 4px;
+  left: 0;
+  right: 0;
+  bottom: 4px;
+}
+
+.assignment-bar {
+  position: absolute;
+  height: calc(100% - 4px);
+  min-width: 20px;
+  border-radius: 4px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 0 6px;
+  font-size: 11px;
+  color: #fff;
+  cursor: pointer;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
+  transition: box-shadow 0.15s, transform 0.15s;
+  overflow: hidden;
+}
+
+.assignment-bar:hover {
+  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
+  transform: translateY(-1px);
+}
+
+.assignment-bar:focus {
+  outline: 2px solid #3b82f6;
+  outline-offset: 1px;
+}
+
+.assignment-bar.critical {
+  border: 2px solid #991b1b;
+}
+
+.assignment-bar.overallocated {
+  animation: pulse 2s infinite;
+}
+
+@keyframes pulse {
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.8;
+  }
+}
+
+.assignment-bar-label {
+  font-weight: 600;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.assignment-bar-units {
+  font-size: 10px;
+  opacity: 0.9;
+  flex-shrink: 0;
+}
+
+/* Updating indicator */
+.gantt-resource-updating {
+  position: absolute;
+  bottom: 16px;
+  right: 16px;
+  padding: 8px 16px;
+  background: #3b82f6;
+  color: #fff;
+  border-radius: 6px;
+  font-size: 13px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.15);
+}

--- a/web/src/components/GanttResource/GanttResourceView.tsx
+++ b/web/src/components/GanttResource/GanttResourceView.tsx
@@ -1,0 +1,222 @@
+/**
+ * GanttResourceView - Resource-centric schedule visualization.
+ * Shows resources as rows with their assignments displayed as bars across a timeline.
+ */
+
+import { useState, useRef, useCallback, useMemo } from "react";
+import { eachDayOfInterval, addDays } from "date-fns";
+import { useGanttResourceData } from "@/hooks/useGanttResourceData";
+import { ResourceSidebar } from "./ResourceSidebar";
+import { ResourceTimeline } from "./ResourceTimeline";
+import { AssignmentBars } from "./AssignmentBars";
+import { UtilizationOverlay } from "./UtilizationOverlay";
+import type {
+  GanttResourceViewConfig,
+  AssignmentChange,
+  GanttResourceViewProps,
+} from "@/types/ganttResource";
+import "./GanttResourceView.css";
+
+export function GanttResourceView({
+  programId,
+  startDate: propStartDate,
+  endDate: propEndDate,
+  resourceFilter,
+  onAssignmentChange,
+  onAssignmentClick,
+}: GanttResourceViewProps) {
+  // Default to 3-month view - memoize to avoid Date.now() during render
+  const { defaultStart, defaultEnd } = useMemo(() => {
+    const start = propStartDate || new Date();
+    const end = propEndDate || addDays(start, 90);
+    return { defaultStart: start, defaultEnd: end };
+  }, [propStartDate, propEndDate]);
+
+  const [config, setConfig] = useState<GanttResourceViewConfig>({
+    startDate: defaultStart,
+    endDate: defaultEnd,
+    scale: "week",
+    rowHeight: 40,
+    headerHeight: 60,
+    sidebarWidth: 250,
+    showUtilization: true,
+    highlightOverallocations: true,
+  });
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const chartRef = useRef<HTMLDivElement>(null);
+
+  const {
+    resourceLanes,
+    isLoading,
+    error,
+    updateAssignment,
+    isUpdating,
+  } = useGanttResourceData(programId, config.startDate, config.endDate);
+
+  // Filter resources if specified
+  const filteredLanes = resourceFilter
+    ? resourceLanes.filter((lane) => resourceFilter.includes(lane.resourceId))
+    : resourceLanes;
+
+  // Calculate timeline width
+  const days = eachDayOfInterval({
+    start: config.startDate,
+    end: config.endDate,
+  });
+  const dayWidth = config.scale === "day" ? 40 : config.scale === "week" ? 20 : 8;
+  const timelineWidth = days.length * dayWidth;
+
+  // Handle assignment changes
+  const handleAssignmentChange = useCallback(
+    (change: AssignmentChange) => {
+      updateAssignment(change);
+      onAssignmentChange?.(change);
+    },
+    [updateAssignment, onAssignmentChange]
+  );
+
+  // Handle scale change
+  const handleScaleChange = (scale: "day" | "week" | "month") => {
+    setConfig((c) => ({ ...c, scale }));
+  };
+
+  if (isLoading) {
+    return (
+      <div className="gantt-resource-loading" data-testid="gantt-loading">
+        <div className="gantt-resource-spinner" />
+        Loading resource view...
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="gantt-resource-error" data-testid="gantt-error">
+        Error: {(error as Error).message}
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="gantt-resource-container"
+      ref={containerRef}
+      data-testid="gantt-resource-view"
+    >
+      {/* Toolbar */}
+      <div className="gantt-resource-toolbar">
+        <div className="scale-selector">
+          <button
+            className={config.scale === "day" ? "active" : ""}
+            onClick={() => handleScaleChange("day")}
+            data-testid="scale-day"
+          >
+            Day
+          </button>
+          <button
+            className={config.scale === "week" ? "active" : ""}
+            onClick={() => handleScaleChange("week")}
+            data-testid="scale-week"
+          >
+            Week
+          </button>
+          <button
+            className={config.scale === "month" ? "active" : ""}
+            onClick={() => handleScaleChange("month")}
+            data-testid="scale-month"
+          >
+            Month
+          </button>
+        </div>
+        <label className="utilization-toggle">
+          <input
+            type="checkbox"
+            checked={config.showUtilization}
+            onChange={(e) =>
+              setConfig((c) => ({ ...c, showUtilization: e.target.checked }))
+            }
+            data-testid="toggle-utilization"
+          />
+          Show Utilization
+        </label>
+        <label className="overallocation-toggle">
+          <input
+            type="checkbox"
+            checked={config.highlightOverallocations}
+            onChange={(e) =>
+              setConfig((c) => ({
+                ...c,
+                highlightOverallocations: e.target.checked,
+              }))
+            }
+            data-testid="toggle-overallocation"
+          />
+          Highlight Overallocations
+        </label>
+      </div>
+
+      {/* Main content */}
+      <div className="gantt-resource-content">
+        {/* Sidebar */}
+        <div
+          className="gantt-resource-sidebar"
+          style={{ width: config.sidebarWidth }}
+        >
+          <ResourceSidebar
+            resources={filteredLanes}
+            rowHeight={config.rowHeight}
+            headerHeight={config.headerHeight}
+          />
+        </div>
+
+        {/* Chart area */}
+        <div
+          className="gantt-resource-chart"
+          ref={chartRef}
+          style={{ width: `calc(100% - ${config.sidebarWidth}px)` }}
+        >
+          <ResourceTimeline config={config} width={timelineWidth} />
+          <div
+            className="gantt-resource-lanes"
+            style={{ width: timelineWidth }}
+          >
+            {filteredLanes.map((lane, index) => (
+              <div
+                key={lane.resourceId}
+                className="gantt-resource-lane"
+                style={{
+                  height: config.rowHeight,
+                  top: index * config.rowHeight,
+                }}
+                data-testid={`resource-lane-${lane.resourceId}`}
+              >
+                {config.showUtilization && (
+                  <UtilizationOverlay
+                    lane={lane}
+                    config={config}
+                    dayWidth={dayWidth}
+                  />
+                )}
+                <AssignmentBars
+                  assignments={lane.assignments}
+                  config={config}
+                  dayWidth={dayWidth}
+                  highlightOverallocations={config.highlightOverallocations}
+                  onAssignmentClick={onAssignmentClick}
+                  onAssignmentChange={handleAssignmentChange}
+                />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {isUpdating && (
+        <div className="gantt-resource-updating" data-testid="gantt-updating">
+          Saving...
+        </div>
+      )}
+    </div>
+  );
+}

--- a/web/src/components/GanttResource/ResourceSidebar.tsx
+++ b/web/src/components/GanttResource/ResourceSidebar.tsx
@@ -1,0 +1,72 @@
+/**
+ * ResourceSidebar - Shows resource information in the left panel.
+ */
+
+import type { ResourceLane } from "@/types/ganttResource";
+
+interface ResourceSidebarProps {
+  resources: ResourceLane[];
+  rowHeight: number;
+  headerHeight: number;
+}
+
+const resourceTypeIcons: Record<string, string> = {
+  labor: "L",
+  equipment: "E",
+  material: "M",
+};
+
+const resourceTypeColors: Record<string, string> = {
+  labor: "#3b82f6",
+  equipment: "#f59e0b",
+  material: "#10b981",
+};
+
+export function ResourceSidebar({
+  resources,
+  rowHeight,
+  headerHeight,
+}: ResourceSidebarProps) {
+  return (
+    <div className="resource-sidebar" data-testid="resource-sidebar">
+      {/* Header */}
+      <div
+        className="resource-sidebar-header"
+        style={{ height: headerHeight }}
+      >
+        <span className="resource-sidebar-title">Resources</span>
+      </div>
+
+      {/* Resource rows */}
+      <div className="resource-sidebar-rows">
+        {resources.map((resource) => (
+          <div
+            key={resource.resourceId}
+            className="resource-sidebar-row"
+            style={{ height: rowHeight }}
+            data-testid={`sidebar-row-${resource.resourceId}`}
+          >
+            <span
+              className="resource-type-badge"
+              style={{
+                backgroundColor: resourceTypeColors[resource.resourceType],
+              }}
+              title={resource.resourceType}
+            >
+              {resourceTypeIcons[resource.resourceType]}
+            </span>
+            <div className="resource-info">
+              <span className="resource-code">{resource.resourceCode}</span>
+              <span className="resource-name" title={resource.resourceName}>
+                {resource.resourceName}
+              </span>
+            </div>
+            <span className="resource-capacity">
+              {resource.capacityPerDay}h/d
+            </span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/GanttResource/ResourceTimeline.tsx
+++ b/web/src/components/GanttResource/ResourceTimeline.tsx
@@ -1,0 +1,116 @@
+/**
+ * ResourceTimeline - Displays the timeline header with date labels.
+ */
+
+import {
+  format,
+  eachDayOfInterval,
+  startOfWeek,
+  startOfMonth,
+  isSameDay,
+  isWeekend,
+} from "date-fns";
+import type { GanttResourceViewConfig } from "@/types/ganttResource";
+
+interface ResourceTimelineProps {
+  config: GanttResourceViewConfig;
+  width: number;
+}
+
+export function ResourceTimeline({ config, width }: ResourceTimelineProps) {
+  const days = eachDayOfInterval({
+    start: config.startDate,
+    end: config.endDate,
+  });
+  const dayWidth =
+    config.scale === "day" ? 40 : config.scale === "week" ? 20 : 8;
+
+  // Generate month/week headers
+  const monthHeaders: { label: string; startIndex: number; span: number }[] =
+    [];
+  let currentMonth: string | null = null;
+  let currentMonthStart = 0;
+
+  days.forEach((day, index) => {
+    const monthKey = format(day, "MMM yyyy");
+    if (monthKey !== currentMonth) {
+      if (currentMonth !== null) {
+        monthHeaders.push({
+          label: currentMonth,
+          startIndex: currentMonthStart,
+          span: index - currentMonthStart,
+        });
+      }
+      currentMonth = monthKey;
+      currentMonthStart = index;
+    }
+  });
+  // Push the last month
+  if (currentMonth !== null) {
+    monthHeaders.push({
+      label: currentMonth,
+      startIndex: currentMonthStart,
+      span: days.length - currentMonthStart,
+    });
+  }
+
+  // Determine which days to show labels for
+  const shouldShowLabel = (day: Date): boolean => {
+    if (config.scale === "day") {
+      return true;
+    }
+    if (config.scale === "week") {
+      return isSameDay(day, startOfWeek(day, { weekStartsOn: 1 }));
+    }
+    // Month scale - show first of month
+    return isSameDay(day, startOfMonth(day));
+  };
+
+  return (
+    <div
+      className="resource-timeline"
+      style={{ width, height: config.headerHeight }}
+      data-testid="resource-timeline"
+    >
+      {/* Month row */}
+      <div className="timeline-months">
+        {monthHeaders.map((header, idx) => (
+          <div
+            key={idx}
+            className="timeline-month"
+            style={{
+              left: header.startIndex * dayWidth,
+              width: header.span * dayWidth,
+            }}
+          >
+            {header.label}
+          </div>
+        ))}
+      </div>
+
+      {/* Day row */}
+      <div className="timeline-days">
+        {days.map((day, index) => (
+          <div
+            key={index}
+            className={`timeline-day ${isWeekend(day) ? "weekend" : ""}`}
+            style={{
+              left: index * dayWidth,
+              width: dayWidth,
+            }}
+          >
+            {shouldShowLabel(day) && (
+              <span className="timeline-day-label">
+                {config.scale === "day"
+                  ? format(day, "d")
+                  : config.scale === "week"
+                  ? format(day, "d")
+                  : format(day, "d")}
+              </span>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/web/src/components/GanttResource/UtilizationOverlay.tsx
+++ b/web/src/components/GanttResource/UtilizationOverlay.tsx
@@ -1,0 +1,77 @@
+/**
+ * UtilizationOverlay - Shows daily utilization as background color intensity.
+ */
+
+import { eachDayOfInterval } from "date-fns";
+import type {
+  ResourceLane,
+  GanttResourceViewConfig,
+} from "@/types/ganttResource";
+
+interface UtilizationOverlayProps {
+  lane: ResourceLane;
+  config: GanttResourceViewConfig;
+  dayWidth: number;
+}
+
+function getUtilizationColor(utilization: number, capacity: number): string {
+  const percentage = capacity > 0 ? utilization / capacity : 0;
+
+  if (percentage === 0) {
+    return "transparent";
+  }
+  if (percentage <= 0.5) {
+    // Light green for under-utilized
+    return `rgba(34, 197, 94, ${percentage * 0.3})`;
+  }
+  if (percentage <= 0.8) {
+    // Yellow for moderate
+    return `rgba(234, 179, 8, ${percentage * 0.4})`;
+  }
+  if (percentage <= 1.0) {
+    // Light orange for near capacity
+    return `rgba(249, 115, 22, ${percentage * 0.4})`;
+  }
+  // Red for overallocated
+  return `rgba(239, 68, 68, ${Math.min(percentage * 0.5, 0.6)})`;
+}
+
+export function UtilizationOverlay({
+  lane,
+  config,
+  dayWidth,
+}: UtilizationOverlayProps) {
+  const days = eachDayOfInterval({
+    start: config.startDate,
+    end: config.endDate,
+  });
+
+  return (
+    <div
+      className="utilization-overlay"
+      data-testid={`utilization-overlay-${lane.resourceId}`}
+    >
+      {days.map((day, index) => {
+        const dateKey = day.toISOString().split("T")[0];
+        const utilization = lane.dailyUtilization.get(dateKey) || 0;
+        const color = getUtilizationColor(utilization, lane.capacityPerDay);
+
+        return (
+          <div
+            key={index}
+            className="utilization-cell"
+            style={{
+              left: index * dayWidth,
+              width: dayWidth,
+              backgroundColor: color,
+            }}
+            title={`${dateKey}: ${utilization.toFixed(1)}h / ${lane.capacityPerDay}h (${(
+              (utilization / lane.capacityPerDay) *
+              100
+            ).toFixed(0)}%)`}
+          />
+        );
+      })}
+    </div>
+  );
+}

--- a/web/src/components/GanttResource/__tests__/GanttResourceView.test.tsx
+++ b/web/src/components/GanttResource/__tests__/GanttResourceView.test.tsx
@@ -1,0 +1,317 @@
+/**
+ * Unit tests for GanttResourceView component.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { GanttResourceView } from "../GanttResourceView";
+
+// Mock the API client
+vi.mock("@/api/client", () => ({
+  apiClient: {
+    get: vi.fn(),
+    patch: vi.fn(),
+    delete: vi.fn(),
+  },
+}));
+
+// Import the mocked client
+import { apiClient } from "@/api/client";
+
+const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      retry: false,
+    },
+  },
+});
+
+const wrapper = ({ children }: { children: React.ReactNode }) => (
+  <QueryClientProvider client={queryClient}>{children}</QueryClientProvider>
+);
+
+const mockResources = {
+  items: [
+    {
+      id: "res-1",
+      code: "ENG-001",
+      name: "Senior Engineer",
+      resource_type: "LABOR",
+      capacity_per_day: "8.0",
+    },
+    {
+      id: "res-2",
+      code: "EQP-001",
+      name: "Crane A",
+      resource_type: "EQUIPMENT",
+      capacity_per_day: "10.0",
+    },
+  ],
+};
+
+const mockAssignments = {
+  items: [
+    {
+      id: "assign-1",
+      activity_id: "act-1",
+      start_date: "2026-02-01",
+      finish_date: "2026-02-10",
+      units: "1.0",
+      activity: {
+        code: "ACT-001",
+        name: "Design Review",
+        early_start: "2026-02-01",
+        early_finish: "2026-02-10",
+        is_critical: false,
+      },
+    },
+  ],
+};
+
+describe("GanttResourceView", () => {
+  beforeEach(() => {
+    queryClient.clear();
+    vi.clearAllMocks();
+  });
+
+  it("renders loading state initially", () => {
+    vi.mocked(apiClient.get).mockImplementation(() => new Promise(() => {}));
+
+    render(<GanttResourceView programId="test-program" />, { wrapper });
+
+    expect(screen.getByTestId("gantt-loading")).toBeInTheDocument();
+    expect(screen.getByText(/loading/i)).toBeInTheDocument();
+  });
+
+  it("renders scale selector buttons", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockResources });
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { items: [] } });
+
+    render(<GanttResourceView programId="test-program" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scale-day")).toBeInTheDocument();
+    });
+
+    expect(screen.getByTestId("scale-week")).toBeInTheDocument();
+    expect(screen.getByTestId("scale-month")).toBeInTheDocument();
+  });
+
+  it("renders resource sidebar with resources", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockResources });
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { items: [] } });
+
+    render(<GanttResourceView programId="test-program" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("resource-sidebar")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("ENG-001")).toBeInTheDocument();
+    expect(screen.getByText("Senior Engineer")).toBeInTheDocument();
+    expect(screen.getByText("EQP-001")).toBeInTheDocument();
+    expect(screen.getByText("Crane A")).toBeInTheDocument();
+  });
+
+  it("toggles utilization display", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockResources });
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { items: [] } });
+
+    render(<GanttResourceView programId="test-program" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("toggle-utilization")).toBeInTheDocument();
+    });
+
+    const toggle = screen.getByTestId("toggle-utilization");
+    expect(toggle).toBeChecked();
+
+    fireEvent.click(toggle);
+    expect(toggle).not.toBeChecked();
+  });
+
+  it("toggles overallocation highlight", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockResources });
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { items: [] } });
+
+    render(<GanttResourceView programId="test-program" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("toggle-overallocation")).toBeInTheDocument();
+    });
+
+    const toggle = screen.getByTestId("toggle-overallocation");
+    expect(toggle).toBeChecked();
+
+    fireEvent.click(toggle);
+    expect(toggle).not.toBeChecked();
+  });
+
+  it("changes scale when scale button is clicked", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockResources });
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { items: [] } });
+
+    render(<GanttResourceView programId="test-program" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("scale-day")).toBeInTheDocument();
+    });
+
+    // Default is week
+    expect(screen.getByTestId("scale-week")).toHaveClass("active");
+
+    // Click day
+    fireEvent.click(screen.getByTestId("scale-day"));
+    expect(screen.getByTestId("scale-day")).toHaveClass("active");
+    expect(screen.getByTestId("scale-week")).not.toHaveClass("active");
+
+    // Click month
+    fireEvent.click(screen.getByTestId("scale-month"));
+    expect(screen.getByTestId("scale-month")).toHaveClass("active");
+    expect(screen.getByTestId("scale-day")).not.toHaveClass("active");
+  });
+
+  it("renders error state when API fails", async () => {
+    vi.mocked(apiClient.get).mockRejectedValue(new Error("API Error"));
+
+    render(<GanttResourceView programId="test-program" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("gantt-error")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/API Error/)).toBeInTheDocument();
+  });
+
+  it("renders timeline header", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockResources });
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { items: [] } });
+
+    render(<GanttResourceView programId="test-program" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("resource-timeline")).toBeInTheDocument();
+    });
+  });
+
+  it("calls onAssignmentClick when assignment is clicked", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockResources });
+    // Only return assignments for the first resource
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockAssignments });
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: { items: [] } });
+
+    const handleClick = vi.fn();
+
+    render(
+      <GanttResourceView
+        programId="test-program"
+        onAssignmentClick={handleClick}
+      />,
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assignment-bar-assign-1")).toBeInTheDocument();
+    });
+
+    fireEvent.click(screen.getByTestId("assignment-bar-assign-1"));
+    expect(handleClick).toHaveBeenCalledWith("assign-1");
+  });
+
+  it("filters resources when resourceFilter is provided", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockResources });
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { items: [] } });
+
+    render(
+      <GanttResourceView programId="test-program" resourceFilter={["res-1"]} />,
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("ENG-001")).toBeInTheDocument();
+    });
+
+    expect(screen.queryByText("EQP-001")).not.toBeInTheDocument();
+  });
+});
+
+describe("ResourceSidebar", () => {
+  it("displays resource type badges", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockResources });
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { items: [] } });
+
+    render(<GanttResourceView programId="test-program" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("resource-sidebar")).toBeInTheDocument();
+    });
+
+    // Check for type badges (L for Labor, E for Equipment)
+    const laborBadge = screen.getByText("L");
+    const equipmentBadge = screen.getByText("E");
+
+    expect(laborBadge).toBeInTheDocument();
+    expect(equipmentBadge).toBeInTheDocument();
+  });
+
+  it("displays resource capacity", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockResources });
+    vi.mocked(apiClient.get).mockResolvedValue({ data: { items: [] } });
+
+    render(<GanttResourceView programId="test-program" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByText("8h/d")).toBeInTheDocument();
+      expect(screen.getByText("10h/d")).toBeInTheDocument();
+    });
+  });
+});
+
+describe("AssignmentBars", () => {
+  it("renders assignment bars with correct labels", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockResources });
+    // Only return assignments for the first resource
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockAssignments });
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: { items: [] } });
+
+    render(<GanttResourceView programId="test-program" />, { wrapper });
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assignment-bar-assign-1")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("ACT-001")).toBeInTheDocument();
+    expect(screen.getByText("100%")).toBeInTheDocument();
+  });
+
+  it("handles keyboard delete on assignment", async () => {
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockResources });
+    // Only return assignments for the first resource
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: mockAssignments });
+    vi.mocked(apiClient.get).mockResolvedValueOnce({ data: { items: [] } });
+    vi.mocked(apiClient.delete).mockResolvedValue({});
+
+    const handleChange = vi.fn();
+
+    render(
+      <GanttResourceView
+        programId="test-program"
+        onAssignmentChange={handleChange}
+      />,
+      { wrapper }
+    );
+
+    await waitFor(() => {
+      expect(screen.getByTestId("assignment-bar-assign-1")).toBeInTheDocument();
+    });
+
+    const assignmentBar = screen.getByTestId("assignment-bar-assign-1");
+    fireEvent.keyDown(assignmentBar, { key: "Delete" });
+
+    expect(handleChange).toHaveBeenCalledWith({
+      assignmentId: "assign-1",
+      type: "delete",
+    });
+  });
+});

--- a/web/src/components/GanttResource/index.ts
+++ b/web/src/components/GanttResource/index.ts
@@ -1,0 +1,9 @@
+/**
+ * GanttResource component exports.
+ */
+
+export { GanttResourceView } from "./GanttResourceView";
+export { ResourceSidebar } from "./ResourceSidebar";
+export { ResourceTimeline } from "./ResourceTimeline";
+export { AssignmentBars } from "./AssignmentBars";
+export { UtilizationOverlay } from "./UtilizationOverlay";

--- a/web/src/components/index.ts
+++ b/web/src/components/index.ts
@@ -15,3 +15,4 @@ export { WBSTree } from './WBSTree/WBSTree';
 export { EVMSDashboard } from './EVMSDashboard/EVMSDashboard';
 export { ImportModal } from './Import/ImportModal';
 export { ResourceList, ResourceForm, AssignmentModal, ResourceHistogram, LevelingPanel } from './Resources';
+export { GanttResourceView } from './GanttResource';

--- a/web/src/hooks/useGanttResourceData.ts
+++ b/web/src/hooks/useGanttResourceData.ts
@@ -1,0 +1,172 @@
+/**
+ * Hook for fetching and managing Gantt resource view data.
+ */
+
+import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
+import { apiClient } from "@/api/client";
+import type {
+  ResourceLane,
+  AssignmentBar,
+  AssignmentChange,
+} from "@/types/ganttResource";
+
+interface ResourceResponse {
+  id: string;
+  code: string;
+  name: string;
+  resource_type: string;
+  capacity_per_day: string;
+}
+
+interface AssignmentResponse {
+  id: string;
+  activity_id: string;
+  start_date: string | null;
+  finish_date: string | null;
+  units: string;
+  activity?: {
+    code: string;
+    name: string;
+    early_start: string | null;
+    early_finish: string | null;
+    is_critical: boolean;
+  };
+}
+
+function calculateUtilization(lanes: ResourceLane[]): ResourceLane[] {
+  return lanes.map((lane) => {
+    const utilization = new Map<string, number>();
+
+    // Calculate daily utilization
+    lane.assignments.forEach((assignment) => {
+      const current = new Date(assignment.startDate);
+      while (current <= assignment.endDate) {
+        const dateKey = current.toISOString().split("T")[0];
+        const existing = utilization.get(dateKey) || 0;
+        utilization.set(
+          dateKey,
+          existing + assignment.units * lane.capacityPerDay
+        );
+        current.setDate(current.getDate() + 1);
+      }
+    });
+
+    // Mark overallocated assignments
+    const updatedAssignments = lane.assignments.map((assignment) => {
+      let isOverallocated = false;
+      const current = new Date(assignment.startDate);
+      while (current <= assignment.endDate) {
+        const dateKey = current.toISOString().split("T")[0];
+        if ((utilization.get(dateKey) || 0) > lane.capacityPerDay) {
+          isOverallocated = true;
+          break;
+        }
+        current.setDate(current.getDate() + 1);
+      }
+      return { ...assignment, isOverallocated };
+    });
+
+    return {
+      ...lane,
+      assignments: updatedAssignments,
+      dailyUtilization: utilization,
+    };
+  });
+}
+
+export function useGanttResourceData(
+  programId: string,
+  startDate: Date,
+  endDate: Date
+) {
+  const queryClient = useQueryClient();
+
+  // Fetch resources with assignments
+  const resourcesQuery = useQuery({
+    queryKey: [
+      "gantt-resources",
+      programId,
+      startDate.toISOString(),
+      endDate.toISOString(),
+    ],
+    queryFn: async () => {
+      // Get resources
+      const resourcesRes = await apiClient.get<{ items: ResourceResponse[] }>(
+        `/resources?program_id=${programId}`
+      );
+      const resources = resourcesRes.data.items;
+
+      // Get assignments for each resource
+      const resourceLanes: ResourceLane[] = await Promise.all(
+        resources.map(async (resource) => {
+          const assignmentsRes = await apiClient.get<{
+            items: AssignmentResponse[];
+          }>(
+            `/resources/${resource.id}/assignments?start_date=${startDate.toISOString()}&end_date=${endDate.toISOString()}`
+          );
+
+          const assignments: AssignmentBar[] = assignmentsRes.data.items.map(
+            (a) => ({
+              assignmentId: a.id,
+              activityId: a.activity_id,
+              activityCode: a.activity?.code || "",
+              activityName: a.activity?.name || "",
+              startDate: new Date(
+                a.start_date || a.activity?.early_start || new Date()
+              ),
+              endDate: new Date(
+                a.finish_date || a.activity?.early_finish || new Date()
+              ),
+              units: parseFloat(a.units),
+              isCritical: a.activity?.is_critical || false,
+              isOverallocated: false, // Will be calculated
+            })
+          );
+
+          return {
+            resourceId: resource.id,
+            resourceCode: resource.code,
+            resourceName: resource.name,
+            resourceType: resource.resource_type.toLowerCase() as
+              | "labor"
+              | "equipment"
+              | "material",
+            capacityPerDay: parseFloat(resource.capacity_per_day),
+            assignments,
+            dailyUtilization: new Map(),
+          } as ResourceLane;
+        })
+      );
+
+      // Calculate utilization and overallocation
+      return calculateUtilization(resourceLanes);
+    },
+    enabled: !!programId,
+  });
+
+  // Mutation for updating assignments
+  const updateAssignment = useMutation({
+    mutationFn: async (change: AssignmentChange) => {
+      if (change.type === "delete") {
+        return apiClient.delete(`/assignments/${change.assignmentId}`);
+      }
+      return apiClient.patch(`/assignments/${change.assignmentId}`, {
+        start_date: change.newStartDate?.toISOString(),
+        finish_date: change.newEndDate?.toISOString(),
+        units: change.newUnits,
+      });
+    },
+    onSuccess: () => {
+      queryClient.invalidateQueries({ queryKey: ["gantt-resources", programId] });
+    },
+  });
+
+  return {
+    resourceLanes: resourcesQuery.data || [],
+    isLoading: resourcesQuery.isLoading,
+    error: resourcesQuery.error,
+    updateAssignment: updateAssignment.mutate,
+    isUpdating: updateAssignment.isPending,
+    refetch: resourcesQuery.refetch,
+  };
+}

--- a/web/src/test/setup.ts
+++ b/web/src/test/setup.ts
@@ -1,0 +1,5 @@
+/**
+ * Test setup file for vitest.
+ */
+
+import "@testing-library/jest-dom";

--- a/web/src/types/ganttResource.ts
+++ b/web/src/types/ganttResource.ts
@@ -1,0 +1,55 @@
+/**
+ * Types for the GanttResourceView component.
+ * Resource-centric schedule visualization types.
+ */
+
+export interface ResourceLane {
+  resourceId: string;
+  resourceCode: string;
+  resourceName: string;
+  resourceType: "labor" | "equipment" | "material";
+  capacityPerDay: number;
+  assignments: AssignmentBar[];
+  dailyUtilization: Map<string, number>; // date -> utilization %
+}
+
+export interface AssignmentBar {
+  assignmentId: string;
+  activityId: string;
+  activityCode: string;
+  activityName: string;
+  startDate: Date;
+  endDate: Date;
+  units: number; // allocation %
+  isCritical: boolean;
+  isOverallocated: boolean;
+  color?: string;
+}
+
+export interface GanttResourceViewConfig {
+  startDate: Date;
+  endDate: Date;
+  scale: "day" | "week" | "month";
+  rowHeight: number;
+  headerHeight: number;
+  sidebarWidth: number;
+  showUtilization: boolean;
+  highlightOverallocations: boolean;
+}
+
+export interface AssignmentChange {
+  assignmentId: string;
+  type: "move" | "resize" | "delete";
+  newStartDate?: Date;
+  newEndDate?: Date;
+  newUnits?: number;
+}
+
+export interface GanttResourceViewProps {
+  programId: string;
+  startDate?: Date;
+  endDate?: Date;
+  resourceFilter?: string[];
+  onAssignmentChange?: (change: AssignmentChange) => void;
+  onAssignmentClick?: (assignmentId: string) => void;
+}

--- a/web/vite.config.ts
+++ b/web/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest" />
 import { defineConfig } from "vite";
 import react from "@vitejs/plugin-react";
 import path from "path";
@@ -23,5 +24,10 @@ export default defineConfig({
         changeOrigin: true,
       },
     },
+  },
+  test: {
+    globals: true,
+    environment: "jsdom",
+    setupFiles: ["./src/test/setup.ts"],
   },
 });


### PR DESCRIPTION
## Summary
- Add GanttResourceView component for resource-centric schedule visualization
- Create TypeScript types for ResourceLane, AssignmentBar, and configuration
- Implement useGanttResourceData hook with utilization calculation
- Add supporting components: ResourceSidebar, ResourceTimeline, AssignmentBars, UtilizationOverlay
- Configure vitest with jsdom environment for React component testing

## Features
- Scale selector (Day/Week/Month view)
- Utilization toggle with color-coded background
- Overallocation highlighting with pulse animation
- Resource type badges (L=Labor, E=Equipment, M=Material)
- Assignment bars with click and keyboard (Delete) handlers
- Responsive CSS styling

## Test plan
- [x] npm run lint passes
- [x] npm run test passes (14 tests)
- [x] npm run build succeeds
- [ ] Manual testing of GanttResourceView in browser

🤖 Generated with [Claude Code](https://claude.ai/code)