### PR TITLE
feat(frontend): add assignment drag-drop editing

### DIFF
--- a/web/src/components/GanttResource/GanttResourceView.css
+++ b/web/src/components/GanttResource/GanttResourceView.css
@@ -294,19 +294,17 @@
   border-radius: 4px;
   display: flex;
   align-items: center;
-  justify-content: space-between;
-  padding: 0 6px;
   font-size: 11px;
   color: #fff;
-  cursor: pointer;
+  cursor: grab;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   transition: box-shadow 0.15s, transform 0.15s;
   overflow: hidden;
+  user-select: none;
 }
 
 .assignment-bar:hover {
-  box-shadow: 0 2px 4px rgba(0, 0, 0, 0.15);
-  transform: translateY(-1px);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.2);
 }
 
 .assignment-bar:focus {
@@ -314,12 +312,26 @@
   outline-offset: 1px;
 }
 
+.assignment-bar.dragging {
+  cursor: grabbing;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
+  transform: scale(1.02);
+  opacity: 0.9;
+  z-index: 100;
+}
+
 .assignment-bar.critical {
   border: 2px solid #991b1b;
 }
 
 .assignment-bar.overallocated {
-  animation: pulse 2s infinite;
+  background: repeating-linear-gradient(
+    45deg,
+    #f97316,
+    #f97316 10px,
+    #ea580c 10px,
+    #ea580c 20px
+  ) !important;
 }
 
 @keyframes pulse {
@@ -332,8 +344,25 @@
   }
 }
 
+/* Assignment bar content - main drag area */
+.assignment-bar-content {
+  flex: 1;
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 0 8px;
+  overflow: hidden;
+  cursor: grab;
+}
+
+.assignment-bar.dragging .assignment-bar-content {
+  cursor: grabbing;
+}
+
 .assignment-bar-label {
-  font-weight: 600;
+  font-size: 12px;
+  font-weight: 500;
+  color: white;
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
@@ -341,8 +370,40 @@
 
 .assignment-bar-units {
   font-size: 10px;
-  opacity: 0.9;
+  color: rgba(255, 255, 255, 0.8);
+  margin-left: 4px;
   flex-shrink: 0;
+}
+
+/* Resize handles */
+.resize-handle {
+  position: absolute;
+  top: 0;
+  width: 8px;
+  height: 100%;
+  cursor: ew-resize;
+  opacity: 0;
+  transition: opacity 0.15s, background-color 0.15s;
+  z-index: 1;
+}
+
+.assignment-bar:hover .resize-handle {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.3);
+}
+
+.resize-handle:hover {
+  background: rgba(255, 255, 255, 0.5) !important;
+}
+
+.resize-start {
+  left: 0;
+  border-radius: 4px 0 0 4px;
+}
+
+.resize-end {
+  right: 0;
+  border-radius: 0 4px 4px 0;
 }
 
 /* Updating indicator */

--- a/web/src/hooks/__tests__/useAssignmentDrag.test.ts
+++ b/web/src/hooks/__tests__/useAssignmentDrag.test.ts
@@ -1,0 +1,334 @@
+/**
+ * Unit tests for useAssignmentDrag hook.
+ */
+
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useAssignmentDrag } from "../useAssignmentDrag";
+import type { AssignmentBar } from "@/types/ganttResource";
+
+describe("useAssignmentDrag", () => {
+  const mockOnChange = vi.fn();
+  const dayWidth = 20;
+
+  const mockAssignment: AssignmentBar = {
+    assignmentId: "test-1",
+    activityId: "act-1",
+    activityCode: "ACT-001",
+    activityName: "Test Activity",
+    startDate: new Date("2026-01-01"),
+    endDate: new Date("2026-01-05"),
+    units: 1.0,
+    isCritical: false,
+    isOverallocated: false,
+  };
+
+  beforeEach(() => {
+    mockOnChange.mockClear();
+  });
+
+  afterEach(() => {
+    // Clean up any global event listeners
+    vi.restoreAllMocks();
+  });
+
+  it("initializes with no drag state", () => {
+    const { result } = renderHook(() =>
+      useAssignmentDrag(dayWidth, mockOnChange)
+    );
+
+    expect(result.current.isDragging).toBe(false);
+    expect(result.current.draggingId).toBeNull();
+    expect(result.current.previewDates).toBeNull();
+    expect(result.current.dragType).toBeNull();
+  });
+
+  it("starts drag on handleDragStart call", () => {
+    const { result } = renderHook(() =>
+      useAssignmentDrag(dayWidth, mockOnChange)
+    );
+
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      clientX: 100,
+    } as unknown as React.MouseEvent;
+
+    act(() => {
+      result.current.handleDragStart(mockEvent, mockAssignment, "move");
+    });
+
+    expect(result.current.isDragging).toBe(true);
+    expect(result.current.draggingId).toBe("test-1");
+    expect(result.current.dragType).toBe("move");
+    expect(result.current.previewDates).not.toBeNull();
+    expect(mockEvent.preventDefault).toHaveBeenCalled();
+    expect(mockEvent.stopPropagation).toHaveBeenCalled();
+  });
+
+  it("supports resize-start drag type", () => {
+    const { result } = renderHook(() =>
+      useAssignmentDrag(dayWidth, mockOnChange)
+    );
+
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      clientX: 100,
+    } as unknown as React.MouseEvent;
+
+    act(() => {
+      result.current.handleDragStart(mockEvent, mockAssignment, "resize-start");
+    });
+
+    expect(result.current.isDragging).toBe(true);
+    expect(result.current.dragType).toBe("resize-start");
+  });
+
+  it("supports resize-end drag type", () => {
+    const { result } = renderHook(() =>
+      useAssignmentDrag(dayWidth, mockOnChange)
+    );
+
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      clientX: 100,
+    } as unknown as React.MouseEvent;
+
+    act(() => {
+      result.current.handleDragStart(mockEvent, mockAssignment, "resize-end");
+    });
+
+    expect(result.current.isDragging).toBe(true);
+    expect(result.current.dragType).toBe("resize-end");
+  });
+
+  it("sets initial preview dates on drag start", () => {
+    const { result } = renderHook(() =>
+      useAssignmentDrag(dayWidth, mockOnChange)
+    );
+
+    const mockEvent = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      clientX: 100,
+    } as unknown as React.MouseEvent;
+
+    act(() => {
+      result.current.handleDragStart(mockEvent, mockAssignment, "move");
+    });
+
+    expect(result.current.previewDates?.start.getTime()).toBe(
+      mockAssignment.startDate.getTime()
+    );
+    expect(result.current.previewDates?.end.getTime()).toBe(
+      mockAssignment.endDate.getTime()
+    );
+  });
+
+  it("updates preview dates on mouse move during drag", () => {
+    const { result } = renderHook(() =>
+      useAssignmentDrag(dayWidth, mockOnChange)
+    );
+
+    const startEvent = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      clientX: 100,
+    } as unknown as React.MouseEvent;
+
+    act(() => {
+      result.current.handleDragStart(startEvent, mockAssignment, "move");
+    });
+
+    // Simulate mouse move (2 days = 40px at dayWidth=20)
+    const moveEvent = new MouseEvent("mousemove", { clientX: 140 });
+
+    act(() => {
+      window.dispatchEvent(moveEvent);
+    });
+
+    // Preview dates should be moved by 2 days
+    const expectedStartDate = new Date("2026-01-03");
+    const expectedEndDate = new Date("2026-01-07");
+
+    expect(result.current.previewDates?.start.toDateString()).toBe(
+      expectedStartDate.toDateString()
+    );
+    expect(result.current.previewDates?.end.toDateString()).toBe(
+      expectedEndDate.toDateString()
+    );
+  });
+
+  it("calls onAssignmentChange on mouse up after move", () => {
+    const { result } = renderHook(() =>
+      useAssignmentDrag(dayWidth, mockOnChange)
+    );
+
+    const startEvent = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      clientX: 100,
+    } as unknown as React.MouseEvent;
+
+    act(() => {
+      result.current.handleDragStart(startEvent, mockAssignment, "move");
+    });
+
+    // Move mouse 2 days
+    const moveEvent = new MouseEvent("mousemove", { clientX: 140 });
+    act(() => {
+      window.dispatchEvent(moveEvent);
+    });
+
+    // Release mouse
+    const upEvent = new MouseEvent("mouseup");
+    act(() => {
+      window.dispatchEvent(upEvent);
+    });
+
+    expect(mockOnChange).toHaveBeenCalledWith({
+      assignmentId: "test-1",
+      type: "move",
+      newStartDate: expect.any(Date),
+      newEndDate: expect.any(Date),
+    });
+  });
+
+  it("calls onAssignmentChange with resize type on resize-end", () => {
+    const { result } = renderHook(() =>
+      useAssignmentDrag(dayWidth, mockOnChange)
+    );
+
+    const startEvent = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      clientX: 100,
+    } as unknown as React.MouseEvent;
+
+    act(() => {
+      result.current.handleDragStart(startEvent, mockAssignment, "resize-end");
+    });
+
+    // Move mouse 1 day
+    const moveEvent = new MouseEvent("mousemove", { clientX: 120 });
+    act(() => {
+      window.dispatchEvent(moveEvent);
+    });
+
+    // Release mouse
+    const upEvent = new MouseEvent("mouseup");
+    act(() => {
+      window.dispatchEvent(upEvent);
+    });
+
+    expect(mockOnChange).toHaveBeenCalledWith({
+      assignmentId: "test-1",
+      type: "resize",
+      newStartDate: expect.any(Date),
+      newEndDate: expect.any(Date),
+    });
+  });
+
+  it("does not call onAssignmentChange if dates unchanged", () => {
+    const { result } = renderHook(() =>
+      useAssignmentDrag(dayWidth, mockOnChange)
+    );
+
+    const startEvent = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      clientX: 100,
+    } as unknown as React.MouseEvent;
+
+    act(() => {
+      result.current.handleDragStart(startEvent, mockAssignment, "move");
+    });
+
+    // Release without moving
+    const upEvent = new MouseEvent("mouseup");
+    act(() => {
+      window.dispatchEvent(upEvent);
+    });
+
+    expect(mockOnChange).not.toHaveBeenCalled();
+  });
+
+  it("resets drag state on mouse up", () => {
+    const { result } = renderHook(() =>
+      useAssignmentDrag(dayWidth, mockOnChange)
+    );
+
+    const startEvent = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      clientX: 100,
+    } as unknown as React.MouseEvent;
+
+    act(() => {
+      result.current.handleDragStart(startEvent, mockAssignment, "move");
+    });
+
+    expect(result.current.isDragging).toBe(true);
+
+    const upEvent = new MouseEvent("mouseup");
+    act(() => {
+      window.dispatchEvent(upEvent);
+    });
+
+    expect(result.current.isDragging).toBe(false);
+    expect(result.current.draggingId).toBeNull();
+    expect(result.current.previewDates).toBeNull();
+  });
+
+  it("prevents start date from going past end date on resize-start", () => {
+    const { result } = renderHook(() =>
+      useAssignmentDrag(dayWidth, mockOnChange)
+    );
+
+    const startEvent = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      clientX: 100,
+    } as unknown as React.MouseEvent;
+
+    act(() => {
+      result.current.handleDragStart(startEvent, mockAssignment, "resize-start");
+    });
+
+    // Move start date past end date (10 days forward)
+    const moveEvent = new MouseEvent("mousemove", { clientX: 300 });
+    act(() => {
+      window.dispatchEvent(moveEvent);
+    });
+
+    // Start should be limited to 1 day before end
+    expect(result.current.previewDates!.start < result.current.previewDates!.end).toBe(true);
+  });
+
+  it("prevents end date from going before start date on resize-end", () => {
+    const { result } = renderHook(() =>
+      useAssignmentDrag(dayWidth, mockOnChange)
+    );
+
+    const startEvent = {
+      preventDefault: vi.fn(),
+      stopPropagation: vi.fn(),
+      clientX: 100,
+    } as unknown as React.MouseEvent;
+
+    act(() => {
+      result.current.handleDragStart(startEvent, mockAssignment, "resize-end");
+    });
+
+    // Move end date before start date (10 days backward)
+    const moveEvent = new MouseEvent("mousemove", { clientX: -100 });
+    act(() => {
+      window.dispatchEvent(moveEvent);
+    });
+
+    // End should be limited to 1 day after start
+    expect(result.current.previewDates!.end > result.current.previewDates!.start).toBe(true);
+  });
+});

--- a/web/src/hooks/useAssignmentDrag.ts
+++ b/web/src/hooks/useAssignmentDrag.ts
@@ -1,0 +1,139 @@
+/**
+ * Hook for managing assignment drag-and-drop state.
+ * Supports move (change dates) and resize (change duration) operations.
+ */
+
+import { useState, useCallback, useEffect, type MouseEvent } from "react";
+import type { AssignmentBar, AssignmentChange } from "@/types/ganttResource";
+
+interface DragState {
+  assignmentId: string;
+  type: "move" | "resize-start" | "resize-end";
+  initialX: number;
+  initialStart: Date;
+  initialEnd: Date;
+  currentX: number;
+}
+
+export function useAssignmentDrag(
+  dayWidth: number,
+  onAssignmentChange: (change: AssignmentChange) => void
+) {
+  const [dragState, setDragState] = useState<DragState | null>(null);
+  const [previewDates, setPreviewDates] = useState<{
+    start: Date;
+    end: Date;
+  } | null>(null);
+
+  const handleDragStart = useCallback(
+    (
+      e: MouseEvent,
+      assignment: AssignmentBar,
+      type: "move" | "resize-start" | "resize-end"
+    ) => {
+      e.preventDefault();
+      e.stopPropagation();
+
+      setDragState({
+        assignmentId: assignment.assignmentId,
+        type,
+        initialX: e.clientX,
+        initialStart: new Date(assignment.startDate),
+        initialEnd: new Date(assignment.endDate),
+        currentX: e.clientX,
+      });
+
+      // Set initial preview
+      setPreviewDates({
+        start: new Date(assignment.startDate),
+        end: new Date(assignment.endDate),
+      });
+    },
+    []
+  );
+
+  const handleDragMove = useCallback(
+    (e: globalThis.MouseEvent) => {
+      if (!dragState) return;
+
+      const deltaX = e.clientX - dragState.initialX;
+      const deltaDays = Math.round(deltaX / dayWidth);
+
+      const newStart = new Date(dragState.initialStart);
+      const newEnd = new Date(dragState.initialEnd);
+
+      switch (dragState.type) {
+        case "move":
+          newStart.setDate(newStart.getDate() + deltaDays);
+          newEnd.setDate(newEnd.getDate() + deltaDays);
+          break;
+        case "resize-start":
+          newStart.setDate(newStart.getDate() + deltaDays);
+          // Ensure start doesn't go past end
+          if (newStart >= newEnd) {
+            newStart.setTime(newEnd.getTime() - 86400000); // 1 day before end
+          }
+          break;
+        case "resize-end":
+          newEnd.setDate(newEnd.getDate() + deltaDays);
+          // Ensure end doesn't go before start
+          if (newEnd <= newStart) {
+            newEnd.setTime(newStart.getTime() + 86400000); // 1 day after start
+          }
+          break;
+      }
+
+      setPreviewDates({ start: newStart, end: newEnd });
+      setDragState((prev) => (prev ? { ...prev, currentX: e.clientX } : null));
+    },
+    [dragState, dayWidth]
+  );
+
+  const handleDragEnd = useCallback(() => {
+    if (dragState && previewDates) {
+      // Only fire change if dates actually changed
+      const startChanged =
+        previewDates.start.getTime() !== dragState.initialStart.getTime();
+      const endChanged =
+        previewDates.end.getTime() !== dragState.initialEnd.getTime();
+
+      if (startChanged || endChanged) {
+        onAssignmentChange({
+          assignmentId: dragState.assignmentId,
+          type: dragState.type === "move" ? "move" : "resize",
+          newStartDate: previewDates.start,
+          newEndDate: previewDates.end,
+        });
+      }
+    }
+
+    setDragState(null);
+    setPreviewDates(null);
+  }, [dragState, previewDates, onAssignmentChange]);
+
+  // Global mouse event handlers
+  useEffect(() => {
+    if (dragState) {
+      window.addEventListener("mousemove", handleDragMove);
+      window.addEventListener("mouseup", handleDragEnd);
+      document.body.style.cursor =
+        dragState.type === "move" ? "grabbing" : "ew-resize";
+      document.body.style.userSelect = "none";
+
+      return () => {
+        window.removeEventListener("mousemove", handleDragMove);
+        window.removeEventListener("mouseup", handleDragEnd);
+        document.body.style.cursor = "";
+        document.body.style.userSelect = "";
+      };
+    }
+  }, [dragState, handleDragMove, handleDragEnd]);
+
+  return {
+    isDragging: !!dragState,
+    draggingId: dragState?.assignmentId || null,
+    dragType: dragState?.type || null,
+    previewDates,
+    handleDragStart,
+  };
+}


### PR DESCRIPTION
## Summary
- Add useAssignmentDrag hook for managing drag state (move, resize-start, resize-end)
- Update AssignmentBars with resize handles on both ends
- Add visual feedback during drag (shadow, scale, cursor changes)
- Calculate preview dates in real-time during drag
- Commit changes to API on mouse up
- Prevent invalid date ranges (start >= end)

## Features
- **Move**: Drag bar center to move assignment to new dates
- **Resize Start**: Drag left edge to change start date
- **Resize End**: Drag right edge to change end date
- Visual preview of new dates while dragging
- Cursor changes to indicate drag mode

## Test plan
- [x] npm run lint passes
- [x] npm run test passes (26 tests - 12 new for drag hook)
- [x] npm run build succeeds
- [ ] Manual testing of drag-drop in browser

🤖 Generated with [Claude Code](https://claude.ai/code)